### PR TITLE
Feat/gbi225/make hash functions public

### DIFF
--- a/integration-test/test/isPeginRefundable.test.ts
+++ b/integration-test/test/isPeginRefundable.test.ts
@@ -78,7 +78,7 @@ describe('isPeginRefundable function should', () => {
     // Check in a loop until the quote is refundable
     let response: IsQuoteRefundableResponse = { isRefundable: false }
     while (!response.isRefundable) {
-      response = await flyover.isPeginRefundable(quote, acceptedQuote.signature, txHash)
+      response = await flyover.isPeginRefundable({ quote, providerSignature: acceptedQuote.signature, btcTransactionHash: txHash })
       console.info(`Response: ${JSON.stringify(response)}`)
 
       if (!response.isRefundable) {

--- a/integration-test/test/isPegoutRefundable.test.ts
+++ b/integration-test/test/isPegoutRefundable.test.ts
@@ -54,7 +54,6 @@ describe('FlyoverSDK refund applicability check should', () => {
     let result: IsQuoteRefundableResponse
     do {
       result = await flyover.isPegoutRefundable(quote)
-      console.log('result', result)
       if (result.error !== undefined) {
         await sleepSeconds(CHECK_LOOP_SECONDS_INTERVAL)
         console.debug(`Check if pegout is refundable failed (${result.error.code}), retrying in ${CHECK_LOOP_SECONDS_INTERVAL}...`)

--- a/integration-test/test/isPegoutRefundable.test.ts
+++ b/integration-test/test/isPegoutRefundable.test.ts
@@ -3,7 +3,7 @@ import { assertTruthy, BlockchainConnection } from '@rsksmart/bridges-core-sdk'
 import { Flyover, FlyoverUtils, type IsQuoteRefundableResponse } from '@rsksmart/flyover-sdk'
 import { integrationTestConfig } from '../config'
 import { EXTENDED_TIMEOUT } from './common/constants'
-import { fakeTokenResolver, sleepSeconds } from './common/utils'
+import { fakeTokenResolver, getBitcoinDataSource, sleepSeconds } from './common/utils'
 
 describe('FlyoverSDK refund applicability check should', () => {
   const WAIT_SECONDS_BEFORE_PAYMENT = 30
@@ -22,6 +22,10 @@ describe('FlyoverSDK refund applicability check should', () => {
       integrationTestConfig.nodeUrl
     )
     await flyover.connectToRsk(rsk)
+
+    const bitcoinDataSource = getBitcoinDataSource(integrationTestConfig.network)
+
+    flyover.connectToBitcoin(bitcoinDataSource)
   })
 
   test('verify an expired pegout is refundable', async () => {
@@ -50,6 +54,7 @@ describe('FlyoverSDK refund applicability check should', () => {
     let result: IsQuoteRefundableResponse
     do {
       result = await flyover.isPegoutRefundable(quote)
+      console.log('result', result)
       if (result.error !== undefined) {
         await sleepSeconds(CHECK_LOOP_SECONDS_INTERVAL)
         console.debug(`Check if pegout is refundable failed (${result.error.code}), retrying in ${CHECK_LOOP_SECONDS_INTERVAL}...`)

--- a/integration-test/test/registerPegin.test.ts
+++ b/integration-test/test/registerPegin.test.ts
@@ -78,7 +78,7 @@ describe('refundPegin function should', () => {
     // Check in a loop until the quote is refundable
     let response: IsQuoteRefundableResponse = { isRefundable: false }
     while (!response.isRefundable) {
-      response = await flyover.isPeginRefundable(quote, acceptedQuote.signature, txHash)
+      response = await flyover.isPeginRefundable({ quote, providerSignature: acceptedQuote.signature, btcTransactionHash: txHash })
 
       if (!response.isRefundable) {
         console.info(`The pegin is not refundable yet. Retrying in ${RETRY_INTERVAL / 1000} seconds...`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { Flyover } from './sdk/flyover'
 export { type FlyoverNetworks } from './constants/networks'
 
 export { type RegisterPeginParams } from './sdk/registerPegin'
+export { type IsPeginRefundableParams } from './sdk/isPeginRefundable'
 export { type ValidatePeginTransactionParams, type ValidatePeginTransactionOptions } from './sdk/validatePeginTransaction'
 
 export { FlyoverError } from './client/httpClient'

--- a/src/sdk/flyover.test.ts
+++ b/src/sdk/flyover.test.ts
@@ -963,4 +963,80 @@ describe('Flyover object should', () => {
         .rejects.toThrow('Provider API base URL is not secure. Please enable insecure connections on Flyover configuration')
     })
   })
+
+  describe('hashPeginQuote method should', () => {
+    const MOCK_HASH = '0x6967171f47cfc1dc6e165e09daae7ecb593bbf8b03ed4463214c1fd92ab985a3'
+    const mockLBC: LiquidityBridgeContract = {
+      hashPeginQuote: jest.fn()
+    } as unknown as LiquidityBridgeContract
+
+    beforeEach(() => {
+      (flyover as any).liquidityBridgeContract = mockLBC
+      jest.spyOn(mockLBC, 'hashPeginQuote').mockImplementation(async () => MOCK_HASH)
+    })
+
+    test('call the LBC hashPeginQuote method with the quote', async () => {
+      await flyover.connectToRsk(rskConnectionMock)
+
+      const result = await flyover.hashPeginQuote(quoteMock)
+
+      expect(result).toBe(MOCK_HASH)
+      expect(mockLBC.hashPeginQuote).toHaveBeenCalledWith(quoteMock)
+      expect(mockLBC.hashPeginQuote).toHaveBeenCalledTimes(1)
+    })
+
+    test('throw error when LBC is not initialized', async () => {
+      (flyover as any).liquidityBridgeContract = undefined
+
+      await expect(flyover.hashPeginQuote(quoteMock))
+        .rejects.toThrow('Liquidity bridge contract is not initialized')
+    })
+
+    test('handle LBC hashPeginQuote errors', async () => {
+      const ERROR_MESSAGE = 'Hash calculation failed'
+      const error = new Error(ERROR_MESSAGE)
+      jest.spyOn(mockLBC, 'hashPeginQuote').mockImplementation(async () => { throw error })
+
+      await expect(flyover.hashPeginQuote(quoteMock))
+        .rejects.toThrow(ERROR_MESSAGE)
+    })
+  })
+
+  describe('hashPegoutQuote method should', () => {
+    const MOCK_HASH = '0xc73b616363ef74017a085c60acb96de88b57268708d06ed6a5d21fbf5f08b69b'
+    const mockLBC: LiquidityBridgeContract = {
+      hashPegoutQuote: jest.fn()
+    } as unknown as LiquidityBridgeContract
+
+    beforeEach(() => {
+      (flyover as any).liquidityBridgeContract = mockLBC
+      jest.spyOn(mockLBC, 'hashPegoutQuote').mockImplementation(async () => MOCK_HASH)
+    })
+
+    test('call the LBC hashPegoutQuote method with the quote', async () => {
+      await flyover.connectToRsk(rskConnectionMock)
+
+      const result = await flyover.hashPegoutQuote(pegoutQuoteMock)
+
+      expect(result).toBe(MOCK_HASH)
+      expect(mockLBC.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
+      expect(mockLBC.hashPegoutQuote).toHaveBeenCalledTimes(1)
+    })
+
+    test('throw error when LBC is not initialized', async () => {
+      (flyover as any).liquidityBridgeContract = undefined
+
+      await expect(flyover.hashPegoutQuote(pegoutQuoteMock))
+        .rejects.toThrow('Liquidity bridge contract is not initialized')
+    })
+
+    test('handle LBC hashPegoutQuote errors', async () => {
+      const ERROR_MESSAGE = 'Hash calculation failed'
+      const error = new Error(ERROR_MESSAGE)
+      jest.spyOn(mockLBC, 'hashPegoutQuote').mockImplementation(async () => { throw error })
+
+      await expect(flyover.hashPegoutQuote(pegoutQuoteMock))
+        .rejects.toThrow(ERROR_MESSAGE)
+    })
+  })
 })

--- a/src/sdk/flyover.test.ts
+++ b/src/sdk/flyover.test.ts
@@ -23,7 +23,7 @@ import { isPeginQuotePaid } from './isPeginQuotePaid'
 import { isPegoutQuotePaid } from './isPegoutQuotePaid'
 import { type BitcoinDataSource } from '../bitcoin/BitcoinDataSource'
 import { isPegoutRefundable } from './isPegoutRefundable'
-import { isPeginRefundable } from './isPeginRefundable'
+import { isPeginRefundable, type IsPeginRefundableParams } from './isPeginRefundable'
 jest.mock('ethers')
 
 jest.mock('./getProviders')
@@ -606,10 +606,12 @@ describe('Flyover object should', () => {
     })
   })
 
-  describe('isQuotePaid method should', () => {
+  describe('isQuotePaid method', () => {
+    const MOCK_QUOTE_HASH = 'testQuoteHash'
+
     test('fail if liquidity provider has not been selected', async () => {
       await flyover.connectToRsk(rskConnectionMock)
-      await expect(flyover.isQuotePaid('testQuoteHash', 'pegin'))
+      await expect(flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegin'))
         .rejects.toThrow('You need to select a provider to do this operation')
     })
 
@@ -617,13 +619,16 @@ describe('Flyover object should', () => {
       test('invoke correctly isQuotePaid external function', async () => {
         flyover.useLiquidityProvider(providerMock)
         await flyover.connectToRsk(rskConnectionMock)
-        await flyover.isQuotePaid('testQuoteHash', 'pegin')
+        await flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegin')
+
         expect(isPeginQuotePaid).toBeCalledTimes(1)
         expect(isPeginQuotePaid).toBeCalledWith(
-          (flyover as any).httpClient, // httpClient
-          providerMock, // liquidityProvider
-          'testQuoteHash', // quoteHash
-          rskConnectionMock // rskConnection
+          MOCK_QUOTE_HASH,
+          expect.objectContaining({
+            httpClient: (flyover as any).httpClient,
+            provider: providerMock,
+            rskConnection: rskConnectionMock
+          })
         )
       })
 
@@ -632,20 +637,19 @@ describe('Flyover object should', () => {
         const provider = { ...providerMock }
         provider.apiBaseUrl = 'http://localhost:1234'
         flyover.useLiquidityProvider(provider)
+
         await flyover.connectToRsk(rskConnectionMock)
-        await expect(flyover.isQuotePaid('testQuoteHash', 'pegin'))
+        await expect(flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegin'))
           .rejects.toThrow('Provider API base URL is not secure. Please enable insecure connections on Flyover configuration')
       })
 
       test('fail if not connected to RSK', async () => {
-        // Create a new Flyover instance without RSK connection
         const disconnectedFlyover = new Flyover({
           network: FAKE_NETWORK,
           allowInsecureConnections: true,
           captchaTokenResolver: async () => Promise.resolve('')
         })
 
-        // Set a liquidity provider
         disconnectedFlyover.useLiquidityProvider(providerMock)
 
         // Connect to RSK with a connection that returns undefined for chain height
@@ -656,7 +660,6 @@ describe('Flyover object should', () => {
 
         await disconnectedFlyover.connectToRsk(mockConnectionWithNoHeight)
 
-        // Expect the method to throw an error about needing to connect to RSK
         await expect(disconnectedFlyover.isQuotePaid('testQuoteHash', 'pegin'))
           .rejects.toThrow('Before calling isQuotePaid for pegin quotes, you need to connect to RSK using Flyover.connectToRsk')
       })
@@ -673,25 +676,25 @@ describe('Flyover object should', () => {
         flyover.useLiquidityProvider(providerMock)
         flyover.connectToBitcoin(bitcoinDataSourceMock)
 
-        const result = await flyover.isQuotePaid('testQuoteHash', 'pegout')
+        const result = await flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegout')
 
         expect(result).toEqual({ isPaid: true })
         expect(isPegoutQuotePaid).toBeCalledTimes(1)
         expect(isPegoutQuotePaid).toBeCalledWith(
+          MOCK_QUOTE_HASH,
           expect.objectContaining({
             config: expect.anything(),
             provider: providerMock,
             httpClient: (flyover as any).httpClient,
             btcConnection: bitcoinDataSourceMock
-          }),
-          'testQuoteHash' // quoteHash
+          })
         )
       })
 
       test('fail when bitcoinDataSource is not connected', async () => {
         flyover.useLiquidityProvider(providerMock)
 
-        await expect(flyover.isQuotePaid('testQuoteHash', 'pegout'))
+        await expect(flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegout'))
           .rejects
           .toThrow('Before calling isQuotePaid for pegout quotes, you need to connect to Bitcoin using Flyover.connectToBitcoin')
       })
@@ -701,7 +704,7 @@ describe('Flyover object should', () => {
         flyover.connectToBitcoin(bitcoinDataSourceMock)
         ; (isPegoutQuotePaid as jest.Mock).mockImplementation(async () => Promise.resolve({ isPaid: true }))
 
-        const result = await flyover.isQuotePaid('testQuoteHash', 'pegout')
+        const result = await flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegout')
 
         expect(result).toEqual({ isPaid: true })
       })
@@ -711,7 +714,7 @@ describe('Flyover object should', () => {
         flyover.connectToBitcoin(bitcoinDataSourceMock)
         ; (isPegoutQuotePaid as jest.Mock).mockImplementation(async () => Promise.resolve({ isPaid: false }))
 
-        const result = await flyover.isQuotePaid('testQuoteHash', 'pegout')
+        const result = await flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegout')
 
         expect(result).toEqual({ isPaid: false })
       })
@@ -722,7 +725,7 @@ describe('Flyover object should', () => {
         const errorMessage = 'Failed to check quote payment status'
           ; (isPegoutQuotePaid as jest.Mock).mockImplementation(async () => Promise.reject(new Error(errorMessage)))
 
-        await expect(flyover.isQuotePaid('testQuoteHash', 'pegout'))
+        await expect(flyover.isQuotePaid(MOCK_QUOTE_HASH, 'pegout'))
           .rejects
           .toThrow(errorMessage)
       })
@@ -730,7 +733,7 @@ describe('Flyover object should', () => {
       test('fail when invalid type of operation is provided', async () => {
         flyover.useLiquidityProvider(providerMock)
 
-        await expect(flyover.isQuotePaid('testQuoteHash', 'notPeginNotPegoutOperation' as any))
+        await expect(flyover.isQuotePaid(MOCK_QUOTE_HASH, 'notPeginNotPegoutOperation' as any))
           .rejects
           .toThrow('Invalid type of operation')
       })
@@ -744,14 +747,14 @@ describe('Flyover object should', () => {
       await flyover.isPegoutRefundable(pegoutQuoteMock)
       expect(isPegoutRefundable).toBeCalledTimes(1)
       expect(isPegoutRefundable).toBeCalledWith(
+        pegoutQuoteMock,
         expect.objectContaining({
           config: expect.anything(),
           lbc: expect.any(LiquidityBridgeContract),
           provider: providerMock,
           httpClient: expect.anything(),
           rskConnection: rskConnectionMock
-        }),
-        pegoutQuoteMock
+        })
       )
     })
     test('fail if liquidity provider has not been selected', async () => {
@@ -783,12 +786,20 @@ describe('Flyover object should', () => {
       getBlockFromTransaction: jest.fn()
     } as unknown as BitcoinDataSource
 
+    let params: IsPeginRefundableParams
+
     beforeEach(() => {
-      (isPeginRefundable as jest.Mock).mockImplementation(async () => Promise.resolve({ isRefundable: true }))
+      jest.clearAllMocks()
+      ;(isPeginRefundable as jest.Mock).mockImplementation(async () => Promise.resolve({ isRefundable: true }))
+      params = {
+        quote: quoteMock,
+        providerSignature: signatureMock,
+        btcTransactionHash: FAKE_BTC_TX_HASH
+      }
     })
 
     test('fail if liquidity provider has not been selected', async () => {
-      await expect(flyover.isPeginRefundable(quoteMock, signatureMock, FAKE_BTC_TX_HASH))
+      await expect(flyover.isPeginRefundable(params))
         .rejects.toThrow('You need to select a provider to do this operation')
     })
 
@@ -797,16 +808,16 @@ describe('Flyover object should', () => {
       await flyover.connectToRsk(rskConnectionMock)
       flyover.connectToBitcoin(bitcoinDataSourceMock)
 
-      const result = await flyover.isPeginRefundable(quoteMock, signatureMock, FAKE_BTC_TX_HASH)
+      const result = await flyover.isPeginRefundable(params)
 
       expect(result).toEqual({ isRefundable: true })
       expect(isPeginRefundable).toBeCalledTimes(1)
       expect(isPeginRefundable).toBeCalledWith({
         quote: quoteMock,
         providerSignature: signatureMock,
-        btcTransactionHash: FAKE_BTC_TX_HASH,
-        flyoverContext: (flyover as any).getFlyoverContext()
-      })
+        btcTransactionHash: FAKE_BTC_TX_HASH
+      },
+      (flyover as any).getFlyoverContext())
     })
 
     test('fail when not connected to RSK', async () => {
@@ -815,7 +826,7 @@ describe('Flyover object should', () => {
 
       jest.spyOn(flyover, 'isConnected').mockImplementation(async () => Promise.resolve(false))
 
-      await expect(flyover.isPeginRefundable(quoteMock, signatureMock, FAKE_BTC_TX_HASH))
+      await expect(flyover.isPeginRefundable(params))
         .rejects.toThrow('Not connected to RSK')
     })
 
@@ -823,7 +834,7 @@ describe('Flyover object should', () => {
       flyover.useLiquidityProvider(providerMock)
       await flyover.connectToRsk(rskConnectionMock)
 
-      await expect(flyover.isPeginRefundable(quoteMock, signatureMock, FAKE_BTC_TX_HASH))
+      await expect(flyover.isPeginRefundable(params))
         .rejects.toThrow('Before calling isPeginQuoteRefundable you need to connect to Bitcoin using Flyover.connectToBitcoin')
     })
 
@@ -835,7 +846,7 @@ describe('Flyover object should', () => {
 
       ;(isPeginRefundable as jest.Mock).mockImplementation(async () => Promise.resolve(FAKE_RESPONSE))
 
-      const result = await flyover.isPeginRefundable(quoteMock, signatureMock, FAKE_BTC_TX_HASH)
+      const result = await flyover.isPeginRefundable(params)
 
       expect(result).toEqual(FAKE_RESPONSE)
     })
@@ -849,7 +860,7 @@ describe('Flyover object should', () => {
       ;(isPeginRefundable as jest.Mock).mockImplementation(async () =>
         Promise.reject(new Error(errorMessage)))
 
-      await expect(flyover.isPeginRefundable(quoteMock, signatureMock, FAKE_BTC_TX_HASH))
+      await expect(flyover.isPeginRefundable(params))
         .rejects.toThrow(errorMessage)
     })
   })

--- a/src/sdk/flyover.test.ts
+++ b/src/sdk/flyover.test.ts
@@ -965,78 +965,114 @@ describe('Flyover object should', () => {
   })
 
   describe('hashPeginQuote method should', () => {
-    const MOCK_HASH = '0x6967171f47cfc1dc6e165e09daae7ecb593bbf8b03ed4463214c1fd92ab985a3'
-    const mockLBC: LiquidityBridgeContract = {
+    const MOCK_HASH = 'mocked-hash-value'
+
+    const mockLiquidityBridgeContract: LiquidityBridgeContract = {
       hashPeginQuote: jest.fn()
     } as unknown as LiquidityBridgeContract
 
     beforeEach(() => {
-      (flyover as any).liquidityBridgeContract = mockLBC
-      jest.spyOn(mockLBC, 'hashPeginQuote').mockImplementation(async () => MOCK_HASH)
+      jest.clearAllMocks()
+
+      jest.spyOn(mockLiquidityBridgeContract, 'hashPeginQuote').mockImplementation(async () => Promise.resolve(MOCK_HASH))
+      ;(flyover as any).liquidityBridgeContract = mockLiquidityBridgeContract
     })
 
-    test('call the LBC hashPeginQuote method with the quote', async () => {
+    test('call liquidityBridgeContract.hashPeginQuote with the correct quote', async () => {
       await flyover.connectToRsk(rskConnectionMock)
 
       const result = await flyover.hashPeginQuote(quoteMock)
 
+      expect(mockLiquidityBridgeContract.hashPeginQuote).toHaveBeenCalledWith(quoteMock)
       expect(result).toBe(MOCK_HASH)
-      expect(mockLBC.hashPeginQuote).toHaveBeenCalledWith(quoteMock)
-      expect(mockLBC.hashPeginQuote).toHaveBeenCalledTimes(1)
     })
 
-    test('throw error when LBC is not initialized', async () => {
-      (flyover as any).liquidityBridgeContract = undefined
+    test('return the hash computed by the LBC contract', async () => {
+      await flyover.connectToRsk(rskConnectionMock)
+      jest.spyOn(LiquidityBridgeContract.prototype, 'hashPeginQuote').mockResolvedValue(MOCK_HASH)
 
-      await expect(flyover.hashPeginQuote(quoteMock))
-        .rejects.toThrow('Liquidity bridge contract is not initialized')
+      const result = await flyover.hashPeginQuote(quoteMock)
+
+      expect(result).toBe(MOCK_HASH)
     })
 
-    test('handle LBC hashPeginQuote errors', async () => {
-      const ERROR_MESSAGE = 'Hash calculation failed'
-      const error = new Error(ERROR_MESSAGE)
-      jest.spyOn(mockLBC, 'hashPeginQuote').mockImplementation(async () => { throw error })
+    test('throw error if not connected to RSK', async () => {
+      await expect(flyover.hashPeginQuote(quoteMock)).rejects.toThrow('Not connected to RSK')
+    })
 
-      await expect(flyover.hashPeginQuote(quoteMock))
-        .rejects.toThrow(ERROR_MESSAGE)
+    test('create LBC instance if not created before', async () => {
+      flyover = new Flyover({
+        network: FAKE_NETWORK,
+        allowInsecureConnections: true,
+        captchaTokenResolver: async () => Promise.resolve('')
+      })
+
+      expect(flyover).not.toHaveProperty('liquidityBridgeContract')
+
+      await flyover.connectToRsk(rskConnectionMock)
+
+      // The result of this call is not important, we just want to check that the LBC instance is created
+      try {
+        await flyover.hashPeginQuote(quoteMock)
+      } catch (error) {}
+
+      expect(flyover).toHaveProperty('liquidityBridgeContract')
     })
   })
 
   describe('hashPegoutQuote method should', () => {
-    const MOCK_HASH = '0xc73b616363ef74017a085c60acb96de88b57268708d06ed6a5d21fbf5f08b69b'
-    const mockLBC: LiquidityBridgeContract = {
+    const MOCK_HASH = 'mocked-pegout-hash-value'
+
+    const mockLiquidityBridgeContract: LiquidityBridgeContract = {
       hashPegoutQuote: jest.fn()
     } as unknown as LiquidityBridgeContract
 
     beforeEach(() => {
-      (flyover as any).liquidityBridgeContract = mockLBC
-      jest.spyOn(mockLBC, 'hashPegoutQuote').mockImplementation(async () => MOCK_HASH)
+      jest.clearAllMocks()
+
+      jest.spyOn(mockLiquidityBridgeContract, 'hashPegoutQuote').mockImplementation(async () => Promise.resolve(MOCK_HASH))
+      ;(flyover as any).liquidityBridgeContract = mockLiquidityBridgeContract
     })
 
-    test('call the LBC hashPegoutQuote method with the quote', async () => {
+    test('call liquidityBridgeContract.hashPegoutQuote with the correct quote', async () => {
       await flyover.connectToRsk(rskConnectionMock)
 
       const result = await flyover.hashPegoutQuote(pegoutQuoteMock)
 
+      expect(mockLiquidityBridgeContract.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
       expect(result).toBe(MOCK_HASH)
-      expect(mockLBC.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
-      expect(mockLBC.hashPegoutQuote).toHaveBeenCalledTimes(1)
     })
 
-    test('throw error when LBC is not initialized', async () => {
-      (flyover as any).liquidityBridgeContract = undefined
+    test('return the hash computed by the LBC contract', async () => {
+      await flyover.connectToRsk(rskConnectionMock)
+      jest.spyOn(LiquidityBridgeContract.prototype, 'hashPegoutQuote').mockResolvedValue(MOCK_HASH)
 
-      await expect(flyover.hashPegoutQuote(pegoutQuoteMock))
-        .rejects.toThrow('Liquidity bridge contract is not initialized')
+      const result = await flyover.hashPegoutQuote(pegoutQuoteMock)
+
+      expect(result).toBe(MOCK_HASH)
     })
 
-    test('handle LBC hashPegoutQuote errors', async () => {
-      const ERROR_MESSAGE = 'Hash calculation failed'
-      const error = new Error(ERROR_MESSAGE)
-      jest.spyOn(mockLBC, 'hashPegoutQuote').mockImplementation(async () => { throw error })
+    test('throw error if not connected to RSK', async () => {
+      await expect(flyover.hashPegoutQuote(pegoutQuoteMock)).rejects.toThrow('Not connected to RSK')
+    })
 
-      await expect(flyover.hashPegoutQuote(pegoutQuoteMock))
-        .rejects.toThrow(ERROR_MESSAGE)
+    test('create LBC instance if not created before', async () => {
+      flyover = new Flyover({
+        network: FAKE_NETWORK,
+        allowInsecureConnections: true,
+        captchaTokenResolver: async () => Promise.resolve('')
+      })
+
+      expect(flyover).not.toHaveProperty('liquidityBridgeContract')
+
+      await flyover.connectToRsk(rskConnectionMock)
+
+      // The result of this call is not important, we just want to check that the LBC instance is created
+      try {
+        await flyover.hashPegoutQuote(pegoutQuoteMock)
+      } catch (error) {}
+
+      expect(flyover).toHaveProperty('liquidityBridgeContract')
     })
   })
 })

--- a/src/sdk/flyover.ts
+++ b/src/sdk/flyover.ts
@@ -21,8 +21,7 @@ import { processError } from '../utils/errorHandling'
 import {
   type CaptchaTokenResolver, type FlyoverConfig,
   getHttpClient, type HttpClient, isBtcAddress, isRskAddress, isSecureUrl,
-  type Network, type Connection, type Bridge, type BridgeMetadata,
-  assertTruthy
+  type Network, type Connection, type Bridge, type BridgeMetadata
 } from '@rsksmart/bridges-core-sdk'
 import { FlyoverError } from '../client/httpClient'
 import { getMetadata } from './getMetadata'
@@ -578,12 +577,14 @@ export class Flyover implements Bridge {
   }
 
   async hashPeginQuote (quote: Quote): Promise<string> {
-    assertTruthy(this.liquidityBridgeContract, 'Liquidity bridge contract is not initialized')
-    return this.liquidityBridgeContract.hashPeginQuote(quote)
+    this.checkLbc()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.liquidityBridgeContract!.hashPeginQuote(quote)
   }
 
   async hashPegoutQuote (quote: PegoutQuote): Promise<string> {
-    assertTruthy(this.liquidityBridgeContract, 'Liquidity bridge contract is not initialized')
-    return this.liquidityBridgeContract.hashPegoutQuote(quote)
+    this.checkLbc()
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.liquidityBridgeContract!.hashPegoutQuote(quote)
   }
 }

--- a/src/sdk/flyover.ts
+++ b/src/sdk/flyover.ts
@@ -21,7 +21,8 @@ import { processError } from '../utils/errorHandling'
 import {
   type CaptchaTokenResolver, type FlyoverConfig,
   getHttpClient, type HttpClient, isBtcAddress, isRskAddress, isSecureUrl,
-  type Network, type Connection, type Bridge, type BridgeMetadata
+  type Network, type Connection, type Bridge, type BridgeMetadata,
+  assertTruthy
 } from '@rsksmart/bridges-core-sdk'
 import { FlyoverError } from '../client/httpClient'
 import { getMetadata } from './getMetadata'
@@ -574,5 +575,15 @@ export class Flyover implements Bridge {
       rskConnection: this.config.rskConnection,
       btcConnection: this.bitcoinDataSource
     }
+  }
+
+  async hashPeginQuote (quote: Quote): Promise<string> {
+    assertTruthy(this.liquidityBridgeContract, 'Liquidity bridge contract is not initialized')
+    return this.liquidityBridgeContract.hashPeginQuote(quote)
+  }
+
+  async hashPegoutQuote (quote: PegoutQuote): Promise<string> {
+    assertTruthy(this.liquidityBridgeContract, 'Liquidity bridge contract is not initialized')
+    return this.liquidityBridgeContract.hashPegoutQuote(quote)
   }
 }

--- a/src/sdk/isPeginQuotePaid.ts
+++ b/src/sdk/isPeginQuotePaid.ts
@@ -1,21 +1,24 @@
 import { getPeginStatus } from './getPeginStatus'
-import { type HttpClient, type Connection } from '@rsksmart/bridges-core-sdk'
+import { assertTruthy, type HttpClient } from '@rsksmart/bridges-core-sdk'
 import { type LiquidityProvider, type PeginQuoteStatus } from '../api'
 import { FlyoverErrors } from '../constants/errors'
 import { parseLBCLogs } from '../blockchain/parsing'
 import { type ContractReceipt } from 'ethers'
-import { type IsQuotePaidResponse } from '../utils/interfaces'
+import { type FlyoverSDKContext, type IsQuotePaidResponse } from '../utils/interfaces'
 
 const MAX_RETRIES = 3
 const RETRY_DELAY = 3000 // 3 seconds
 
 export async function isPeginQuotePaid (
-  httpClient: HttpClient,
-  provider: LiquidityProvider,
   quoteHash: string,
-  rskConnection: Connection
+  context: FlyoverSDKContext
 ): Promise<IsQuotePaidResponse> {
   let peginStatus: PeginQuoteStatus
+
+  const { httpClient, provider, rskConnection } = context
+  assertTruthy(httpClient, 'HTTP client is required')
+  assertTruthy(provider, 'Provider is required')
+  assertTruthy(rskConnection, 'RSK connection is required')
 
   try {
     // Get the pegin status from the Liquidity Provider

--- a/src/sdk/isPegoutQuotePaid.ts
+++ b/src/sdk/isPegoutQuotePaid.ts
@@ -8,14 +8,6 @@ import { type FlyoverSDKContext, type IsQuotePaidResponse } from '../utils/inter
 const MAX_RETRIES = 3
 const RETRY_DELAY = 3000 // 3 seconds
 
-/**
- * Verifies if a Liquidity Provider Service (LPS) has paid a pegout quote by validating both the transaction
- * in the pegout status and its OP_RETURN data.
- *
- * @param quoteHash - The hash of the quote to check if it has been paid.
- * @param context - The context of the Flyover SDK.
- * @returns A promise that resolves to the {@link IsQuotePaidResponse} response.
- */
 export async function isPegoutQuotePaid (
   quoteHash: string,
   context: FlyoverSDKContext

--- a/src/sdk/isPegoutRefundable.test.ts
+++ b/src/sdk/isPegoutRefundable.test.ts
@@ -65,12 +65,12 @@ describe('isPegoutRefundable function should', () => {
   })
   test('return error if the quote is already paid', async () => {
     jest.spyOn(isPaidMod, 'isPegoutQuotePaid').mockResolvedValue({ isPaid: true })
-    const result = await isPegoutRefundable(contextMock, pegoutQuoteMock)
+    const result = await isPegoutRefundable(pegoutQuoteMock, contextMock)
     expect(result.isRefundable).toBe(false)
     expect(result.error).toBe(FlyoverErrors.PEG_OUT_REFUND_ALREADY_PAID)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledTimes(1)
-    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(contextMock, pegoutQuoteMock.quoteHash)
+    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash, contextMock)
     expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledTimes(1)
     expect(lbcMock.isPegOutQuoteCompleted).not.toHaveBeenCalled()
     expect(connectionMock.getChainHeight).not.toHaveBeenCalled()
@@ -80,12 +80,12 @@ describe('isPegoutRefundable function should', () => {
   test('return error if the quote is already completed', async () => {
     jest.spyOn(isPaidMod, 'isPegoutQuotePaid').mockResolvedValue({ isPaid: false, error: FlyoverErrors.QUOTE_STATUS_TRANSACTION_NOT_FOUND })
     lbcMock.isPegOutQuoteCompleted?.mockResolvedValue(true)
-    const result = await isPegoutRefundable(contextMock, pegoutQuoteMock)
+    const result = await isPegoutRefundable(pegoutQuoteMock, contextMock)
     expect(result.isRefundable).toBe(false)
     expect(result.error).toBe(FlyoverErrors.PEG_OUT_REFUND_ALREADY_COMPLETED)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledTimes(1)
-    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(contextMock, pegoutQuoteMock.quoteHash)
+    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash, contextMock)
     expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledTimes(1)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledTimes(1)
@@ -98,12 +98,12 @@ describe('isPegoutRefundable function should', () => {
     lbcMock.isPegOutQuoteCompleted?.mockResolvedValue(false)
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     providerMock.getBlock?.mockResolvedValue({ timestamp: pegoutQuoteMock.quote.expireDate - 5000 } as ethers.providers.Block)
-    const result = await isPegoutRefundable(contextMock, pegoutQuoteMock)
+    const result = await isPegoutRefundable(pegoutQuoteMock, contextMock)
     expect(result.isRefundable).toBe(false)
     expect(result.error).toBe(FlyoverErrors.PEG_OUT_REFUND_NOT_EXPIRED_BY_DATE)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledTimes(1)
-    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(contextMock, pegoutQuoteMock.quoteHash)
+    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash, contextMock)
     expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledTimes(1)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledTimes(1)
@@ -117,12 +117,12 @@ describe('isPegoutRefundable function should', () => {
     lbcMock.isPegOutQuoteCompleted?.mockResolvedValue(false)
     providerMock.getBlock?.mockResolvedValue(expiredBlock)
     connectionMock.getChainHeight?.mockResolvedValue(pegoutQuoteMock.quote.expireBlocks - 1)
-    const result = await isPegoutRefundable(contextMock, pegoutQuoteMock)
+    const result = await isPegoutRefundable(pegoutQuoteMock, contextMock)
     expect(result.isRefundable).toBe(false)
     expect(result.error).toBe(FlyoverErrors.PEG_OUT_REFUND_NOT_EXPIRED_BY_BLOCKS)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledTimes(1)
-    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(contextMock, pegoutQuoteMock.quoteHash)
+    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash, contextMock)
     expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledTimes(1)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledTimes(1)
@@ -144,7 +144,7 @@ describe('isPegoutRefundable function should', () => {
       details: { error: ethersError }
     })
     lbcMock.refundPegout?.mockImplementation(() => { throw bridgeError })
-    const result = await isPegoutRefundable(contextMock, pegoutQuoteMock)
+    const result = await isPegoutRefundable(pegoutQuoteMock, contextMock)
     expect(result.isRefundable).toBe(false)
     expect(result.error).toMatchObject({
       ...FlyoverErrors.PEG_OUT_REFUND_FAILED,
@@ -152,7 +152,7 @@ describe('isPegoutRefundable function should', () => {
     })
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledTimes(1)
-    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(contextMock, pegoutQuoteMock.quoteHash)
+    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash, contextMock)
     expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledTimes(1)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledTimes(1)
@@ -168,12 +168,12 @@ describe('isPegoutRefundable function should', () => {
     providerMock.getBlock?.mockResolvedValue(expiredBlock)
     connectionMock.getChainHeight?.mockResolvedValue(pegoutQuoteMock.quote.expireBlocks + 5)
     lbcMock.refundPegout?.mockResolvedValue(null)
-    const result = await isPegoutRefundable(contextMock, pegoutQuoteMock)
+    const result = await isPegoutRefundable(pegoutQuoteMock, contextMock)
     expect(result.isRefundable).toBe(true)
     expect(result.error).toBeUndefined()
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledWith(pegoutQuoteMock)
     expect(lbcMock.hashPegoutQuote).toHaveBeenCalledTimes(1)
-    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(contextMock, pegoutQuoteMock.quoteHash)
+    expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash, contextMock)
     expect(isPaidMod.isPegoutQuotePaid).toHaveBeenCalledTimes(1)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledWith(pegoutQuoteMock.quoteHash)
     expect(lbcMock.isPegOutQuoteCompleted).toHaveBeenCalledTimes(1)
@@ -182,5 +182,48 @@ describe('isPegoutRefundable function should', () => {
     expect(lbcMock.refundPegout).toHaveBeenCalledTimes(1)
     expect(providerMock.getBlock).toHaveBeenCalledWith('latest')
     expect(providerMock.getBlock).toHaveBeenCalledTimes(1)
+  })
+  test('throw error when lbc in context is missing', async () => {
+    // Test with undefined lbc
+    const contextWithUndefinedLbc = {
+      ...contextMock,
+      lbc: undefined
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      isPegoutRefundable(pegoutQuoteMock, contextWithUndefinedLbc)
+    ).rejects.toThrow('Missing Liquidity Bridge Contract')
+
+    // Test with null lbc
+    const contextWithNullLbc = {
+      ...contextMock,
+      lbc: null
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      isPegoutRefundable(pegoutQuoteMock, contextWithNullLbc)
+    ).rejects.toThrow('Missing Liquidity Bridge Contract')
+  })
+
+  test('throw error when rskConnection in context is missing', async () => {
+    // Test with undefined rskConnection
+    const contextWithUndefinedConnection = {
+      ...contextMock,
+      rskConnection: undefined
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      isPegoutRefundable(pegoutQuoteMock, contextWithUndefinedConnection)
+    ).rejects.toThrow('Missing RSK connection')
+
+    // Test with null rskConnection
+    const contextWithNullConnection = {
+      ...contextMock,
+      rskConnection: null
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      isPegoutRefundable(pegoutQuoteMock, contextWithNullConnection)
+    ).rejects.toThrow('Missing RSK connection')
   })
 })

--- a/src/sdk/isPegoutRefundable.ts
+++ b/src/sdk/isPegoutRefundable.ts
@@ -6,14 +6,15 @@ import { type FlyoverSDKContext, type IsQuoteRefundableResponse } from '../utils
 import { isPegoutQuotePaid } from './isPegoutQuotePaid'
 
 export async function isPegoutRefundable (
-  context: FlyoverSDKContext,
-  quote: PegoutQuote
+  quote: PegoutQuote,
+  context: FlyoverSDKContext
 ): Promise<IsQuoteRefundableResponse> {
   const { lbc, rskConnection } = context
   assertTruthy(lbc, 'Missing Liquidity Bridge Contract')
   assertTruthy(rskConnection, 'Missing RSK connection')
+
   const quoteHash = await lbc.hashPegoutQuote(quote)
-  const result = await isPegoutQuotePaid(context, quoteHash)
+  const result = await isPegoutQuotePaid(quoteHash, context)
   if (result.isPaid) {
     return { isRefundable: false, error: FlyoverErrors.PEG_OUT_REFUND_ALREADY_PAID }
   }

--- a/src/sdk/refundPegout.ts
+++ b/src/sdk/refundPegout.ts
@@ -8,7 +8,7 @@ export async function refundPegout (quote: PegoutQuote, context: FlyoverSDKConte
   validateRequiredFields(quote, ...pegoutQuoteRequiredFields)
   validateRequiredFields(quote.quote, ...pegoutQuoteDetailRequiredFields)
 
-  const isRefundable = await isPegoutRefundable(context, quote)
+  const isRefundable = await isPegoutRefundable(quote, context)
   if (!isRefundable.isRefundable) {
     throw new FlyoverError({
       timestamp: Date.now(),

--- a/src/sdk/registerPegin.test.ts
+++ b/src/sdk/registerPegin.test.ts
@@ -141,9 +141,10 @@ describe('registerPegin function should', () => {
     expect(mockedIsPeginRefundable).toHaveBeenCalledWith({
       quote: MOCK_QUOTE,
       providerSignature: MOCK_PROVIDER_SIGNATURE,
-      btcTransactionHash: MOCK_BTC_TX_HASH,
-      flyoverContext: MOCK_FLYOVER_CONTEXT
-    })
+      btcTransactionHash: MOCK_BTC_TX_HASH
+    },
+    MOCK_FLYOVER_CONTEXT
+    )
 
     expect(mockedGetRawTxWithoutWitnesses).toHaveBeenCalledWith(MOCK_BTC_TX_HASH, MOCK_BTC_DATA_SOURCE)
 
@@ -180,9 +181,10 @@ describe('registerPegin function should', () => {
     expect(mockedIsPeginRefundable).toHaveBeenCalledWith({
       quote: MOCK_QUOTE,
       providerSignature: MOCK_PROVIDER_SIGNATURE,
-      btcTransactionHash: MOCK_BTC_TX_HASH,
-      flyoverContext: MOCK_FLYOVER_CONTEXT
-    })
+      btcTransactionHash: MOCK_BTC_TX_HASH
+    },
+    MOCK_FLYOVER_CONTEXT
+    )
 
     expect(mockedGetRawTxWithoutWitnesses).not.toHaveBeenCalled()
     expect(MOCK_BTC_DATA_SOURCE.getBlockFromTransaction).not.toHaveBeenCalled()
@@ -203,9 +205,10 @@ describe('registerPegin function should', () => {
     expect(mockedIsPeginRefundable).toHaveBeenCalledWith({
       quote: MOCK_QUOTE,
       providerSignature: MOCK_PROVIDER_SIGNATURE,
-      btcTransactionHash: MOCK_BTC_TX_HASH,
-      flyoverContext: MOCK_FLYOVER_CONTEXT
-    })
+      btcTransactionHash: MOCK_BTC_TX_HASH
+    },
+    MOCK_FLYOVER_CONTEXT
+    )
 
     expect(mockedGetRawTxWithoutWitnesses).toHaveBeenCalledWith(MOCK_BTC_TX_HASH, MOCK_BTC_DATA_SOURCE)
     expect(MOCK_BTC_DATA_SOURCE.getBlockFromTransaction).toHaveBeenCalledWith(MOCK_BTC_TX_HASH)
@@ -235,12 +238,57 @@ describe('registerPegin function should', () => {
     expect(mockedIsPeginRefundable).toHaveBeenCalledWith({
       quote: MOCK_QUOTE,
       providerSignature: MOCK_PROVIDER_SIGNATURE,
-      btcTransactionHash: MOCK_BTC_TX_HASH,
-      flyoverContext: MOCK_FLYOVER_CONTEXT
-    })
+      btcTransactionHash: MOCK_BTC_TX_HASH
+    },
+    MOCK_FLYOVER_CONTEXT
+    )
 
     expect(mockedGetRawTxWithoutWitnesses).toHaveBeenCalledWith(MOCK_BTC_TX_HASH, MOCK_BTC_DATA_SOURCE)
     expect(MOCK_BTC_DATA_SOURCE.getBlockFromTransaction).toHaveBeenCalledWith(MOCK_BTC_TX_HASH)
     expect(MOCK_LIQUIDITY_BRIDGE_CONTRACT.registerPegin).not.toHaveBeenCalled()
+  })
+
+  test('throw error when btcConnection in context is missing', async () => {
+    // Test with undefined btcConnection
+    const contextWithUndefinedBtcConnection = {
+      ...MOCK_FLYOVER_CONTEXT,
+      btcConnection: undefined
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      registerPegin(registerPeginParams, contextWithUndefinedBtcConnection)
+    ).rejects.toThrow('Bitcoin connection is required')
+
+    // Test with null btcConnection
+    const contextWithNullBtcConnection = {
+      ...MOCK_FLYOVER_CONTEXT,
+      btcConnection: null
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      registerPegin(registerPeginParams, contextWithNullBtcConnection)
+    ).rejects.toThrow('Bitcoin connection is required')
+  })
+
+  test('throw error when lbc in context is missing', async () => {
+    // Test with undefined lbc
+    const contextWithUndefinedLbc = {
+      ...MOCK_FLYOVER_CONTEXT,
+      lbc: undefined
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      registerPegin(registerPeginParams, contextWithUndefinedLbc)
+    ).rejects.toThrow('Liquidity Bridge Contract is required')
+
+    // Test with null lbc
+    const contextWithNullLbc = {
+      ...MOCK_FLYOVER_CONTEXT,
+      lbc: null
+    } as unknown as FlyoverSDKContext
+
+    await expect(
+      registerPegin(registerPeginParams, contextWithNullLbc)
+    ).rejects.toThrow('Liquidity Bridge Contract is required')
   })
 })


### PR DESCRIPTION
## What 
This PR has two parts:

### First commit:
Refactor refund functions to use FlyoverSDKContext consistently
- Add FlyoverSDKContext to all separated functions used in the refund functionality
- Move FlyoverSDKContext outside of the function parameters object
- Place FlyoverSDKContext as the last parameter
- Add assertions for all required properties in FlyoverSDKContext

Remove unnecessary comments
Fix documentation
Remove refundPegoutQuote mock function from Flyover object

### Second commit
The functions to hash pegin and pegout quotes were in the LBC class and not reachable from outside. On this commit these functions were wrapped and exposed as methods of the Flyover class.

## Why
This PR is the last part of the functionality to ease the process of executing refunds without need of support.

[Jira tk](https://rsklabs.atlassian.net/browse/GBI-2524)