### PR TITLE
fix: add chain id validation to signQuote

### DIFF
--- a/src/sdk/signQuote.test.ts
+++ b/src/sdk/signQuote.test.ts
@@ -232,6 +232,54 @@ describe("signQuote", () => {
     }
     });
 
+    test("throws if pegin domain chain id does not match quote chain id", async () => {
+        const peginCase = peginCases[0];
+        assertTruthy(peginCase);
+        const lbcMock = {
+            pegInContract: {
+                hashPeginQuote: jest.fn<() => Promise<string>>().mockResolvedValue(peginCase.quote.quoteHash),
+                getEip712Domain: jest.fn<() => Promise<unknown>>().mockResolvedValue({ name: 'PegInContract', version: '1', chainId: 1234, verifyingContract:'addr' }),
+            }
+        };
+        const config: FlyoverConfig = { rskConnection: peginCase.connection } as unknown as FlyoverConfig;
+
+        await expect(signQuote(
+            config,
+            lbcMock as unknown as LiquidityBridgeContract,
+            providerMock,
+            peginCase.quote
+        )).rejects.toMatchObject({
+            message: 'Flyover error',
+            details: 'Chain id of domain does not match chain id of quote',
+            timestamp: expect.any(Number),
+            recoverable: true,
+        });
+    });
+
+    test("throws if pegout domain chain id does not match quote chain id", async () => {
+        const pegoutCase = pegoutCases[0];
+        assertTruthy(pegoutCase);
+        const lbcMock = {
+            pegOutContract: {
+                hashPegoutQuote: jest.fn<() => Promise<string>>().mockResolvedValue(pegoutCase.quote.quoteHash),
+                getEip712Domain: jest.fn<() => Promise<unknown>>().mockResolvedValue({ name: 'PegOutContract', version: '1', chainId: 1234, verifyingContract:'addr' }),
+            }
+        };
+        const config: FlyoverConfig = { rskConnection: pegoutCase.connection } as unknown as FlyoverConfig;
+
+        await expect(signQuote(
+            config,
+            lbcMock as unknown as LiquidityBridgeContract,
+            providerMock,
+            pegoutCase.quote
+        )).rejects.toMatchObject({
+            message: 'Flyover error',
+            details: 'Chain id of domain does not match chain id of quote',
+            timestamp: expect.any(Number),
+            recoverable: true,
+        });
+    });
+
    test("throws if rskConnection is not set", async () => {
         assertTruthy(peginQuote)
         const config = { rskConnection: undefined } as unknown as FlyoverConfig;

--- a/src/sdk/signQuote.ts
+++ b/src/sdk/signQuote.ts
@@ -46,6 +46,9 @@ async function signPeginQuote(
         throw FlyoverError.invalidQuoteHashError(lp.apiBaseUrl)
     }
     const domain = await lbc.pegInContract.getEip712Domain()
+    if (BigInt(domain.chainId) !== BigInt(quote.quote.chainId)) {
+        throw FlyoverError.withReason('Chain id of domain does not match chain id of quote')
+    }
     return signer._signTypedData(
         domain,
         {
@@ -72,6 +75,9 @@ async function signPegoutQuote(
         throw FlyoverError.invalidQuoteHashError(lp.apiBaseUrl)
     }
     const domain = await lbc.pegOutContract.getEip712Domain()
+    if (BigInt(domain.chainId) !== BigInt(quote.quote.chainId)) {
+        throw FlyoverError.withReason('Chain id of domain does not match chain id of quote')
+    }
     const signature = await signer._signTypedData(
         domain,
         {


### PR DESCRIPTION
## What
Add validation to the chain id present in the domain inside the `signQuote` function

## Why
To prevent possible replays