### PR TITLE
fix bitcoind rpc gettransaction for mempool transactions

### DIFF
--- a/src/bitcoin/BitcoinRpcDataSource.test.ts
+++ b/src/bitcoin/BitcoinRpcDataSource.test.ts
@@ -160,6 +160,29 @@ describe('LocalBTCDataSource', () => {
       expect(secondCallBody.params).toEqual([mockRawTransaction.blockhash])
     })
 
+    it('should retrieve mempool transaction without calling getblock', async () => {
+      const mempoolTx = {
+        ...mockRawTransaction,
+        confirmations: 0
+      }
+      delete (mempoolTx as { blockhash?: string }).blockhash
+
+      mockFetch.mockImplementationOnce(async () => {
+        return {
+          json: async () => ({ result: mempoolTx })
+        } as Response
+      })
+
+      const result = await bitcoinRpcDataSource.getTransaction(FAKE_TX_ID)
+
+      expect(result.txid).toBe(FAKE_TX_ID)
+      expect(result.isConfirmed).toBe(false)
+      expect(result.blockHash).toBeUndefined()
+      expect(result.blockHeight).toBeUndefined()
+      expect(result.vout).toHaveLength(2)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
     it('should handle network errors', async () => {
       mockFetch.mockImplementationOnce(async () => {
         throw new Error(FAKE_ERROR_MESSAGE)

--- a/src/bitcoin/BitcoinRpcDataSource.ts
+++ b/src/bitcoin/BitcoinRpcDataSource.ts
@@ -36,12 +36,12 @@ function getBitcoinRpcCaller (config: BitcoinClientConfig): RpcCaller {
 
 interface GetRawTransactionResponse {
   txid: string
-  blockhash: string
+  blockhash?: string
+  confirmations?: number
   vout: {
     value:number
     scriptPubKey: { hex: string }
   }[]
-  confirmations: number
   hex: string
 }
 
@@ -69,14 +69,26 @@ export class BitcoindRpcDataSource implements BitcoinDataSource {
       // The second parameter 'true' tells Bitcoin Core to return the full decoded transaction
       const transaction = await this.rpcCaller<GetRawTransactionResponse>('getrawtransaction', txHash, true)
 
+      const confirmations = transaction.confirmations ?? 0
+      const vout = transaction.vout.map((output) => ({
+        valueInSats: output.value * 100_000_000, // Convert BTC to satoshis
+        hex: output.scriptPubKey.hex
+      }))
+
+      // Mempool transactions omit blockhash; calling getblock with undefined would fail
+      if (transaction.blockhash == null || transaction.blockhash === '') {
+        return {
+          txid: transaction.txid,
+          isConfirmed: confirmations >= MIN_BTC_CONFIRMATIONS,
+          vout
+        }
+      }
+
       const btcBlock = await this.rpcCaller<GetBlockResponse>('getblock', transaction.blockhash)
       return {
         txid: transaction.txid,
-        isConfirmed: transaction.confirmations >= MIN_BTC_CONFIRMATIONS,
-        vout: transaction.vout.map((output) => ({
-          valueInSats: output.value * 100_000_000, // Convert BTC to satoshis
-          hex: output.scriptPubKey.hex
-        })),
+        isConfirmed: confirmations >= MIN_BTC_CONFIRMATIONS,
+        vout,
         blockHash: transaction.blockhash,
         blockHeight: btcBlock.height
       }


### PR DESCRIPTION
## what changed

\BitcoindRpcDataSource.getTransaction\ always called \getblock\ after \getrawtransaction\. For transactions still in the mempool, Bitcoin Core does not return \lockhash\, so the follow-up RPC was invalid and the call failed. Integrators using a local bitcoind as the Bitcoin data source could not resolve mempool transactions (for example when tracking a pegout before the first confirmation).

The implementation now skips \getblock\ when \lockhash\ is missing and returns outputs with \isConfirmed\ derived from \confirmations\ only, without block height/hash.

## testing

- Added unit test for mempool-shaped RPC response (single \getrawtransaction\ call, no \getblock\).
- Full Jest suite: \
px jest --runInBand\ (337 tests).

made by mooncitydev