### PR TITLE
fix: validate provider address in quote

### DIFF
--- a/src/sdk/acceptAuthenticatedPegoutQuote.test.ts
+++ b/src/sdk/acceptAuthenticatedPegoutQuote.test.ts
@@ -67,7 +67,7 @@ const pegoutQuoteMock: PegoutQuote = {
     expireDate: 1,
     gasFee: BigInt('1'),
     lbcAddress: 'any address',
-    liquidityProviderRskAddress: 'any address',
+    liquidityProviderRskAddress: providerMock.provider,
     lpBtcAddr: 'any address',
     nonce: BigInt(1),
     penaltyFee: BigInt(1),
@@ -116,6 +116,22 @@ describe('acceptAuthenticatedPegoutQuote function should', () => {
     const invalidQuote = { ...pegoutQuoteMock, quote: {} as PegoutQuoteDetail }
     await expect(acceptAuthenticatedPegoutQuote(mockClient, MOCK_LIQUIDITY_BRIDGE_CONTRACT, providerMock, invalidQuote, signatureMock))
       .rejects.toThrow(`Validation failed for object with following missing properties: ${pegoutQuoteDetailRequiredFields.join(', ')}`)
+  })
+
+  test('validate signature against quote lp address', async () => {
+    const lpAddress = '0xd6F117d8194Eba2fCA8bD63B2E259Dbea40E07d9'
+    const quote = { ...pegoutQuoteMock, quote: { ...pegoutQuoteMock.quote, liquidityProviderRskAddress: lpAddress } }
+    const eip712Hash = '0xeip712hash'
+    jest.spyOn(bridgesCoreSdk, 'isValidSignature').mockReturnValue(true)
+    jest.spyOn(MOCK_LIQUIDITY_BRIDGE_CONTRACT.pegOutContract, 'hashPegoutQuoteEIP712').mockResolvedValue(eip712Hash)
+
+    await acceptAuthenticatedPegoutQuote(mockClient, MOCK_LIQUIDITY_BRIDGE_CONTRACT, providerMock, quote, signatureMock)
+
+    expect(bridgesCoreSdk.isValidSignature).toHaveBeenCalledWith(
+      lpAddress,
+      eip712Hash,
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+    )
   })
 
   test('fail when signature is invalid', async () => {

--- a/src/sdk/acceptAuthenticatedPegoutQuote.ts
+++ b/src/sdk/acceptAuthenticatedPegoutQuote.ts
@@ -19,7 +19,7 @@ export async function acceptAuthenticatedPegoutQuote (httpClient: HttpClient, lb
     { includeCaptcha: false }
   )
   const eip712Hash = await lbc.pegOutContract.hashPegoutQuoteEIP712(quote)
-  if (!isValidSignature(provider.provider, eip712Hash, acceptedQuote.signature)) {
+  if (!isValidSignature(quote.quote.liquidityProviderRskAddress, eip712Hash, acceptedQuote.signature)) {
     throw FlyoverError.invalidSignatureError({
       serverUrl: provider.apiBaseUrl,
       address: quote.quote.liquidityProviderRskAddress,

--- a/src/sdk/acceptAuthenticatedQuote.test.ts
+++ b/src/sdk/acceptAuthenticatedQuote.test.ts
@@ -55,7 +55,7 @@ const quoteMock: Quote = {
   quote: {
     fedBTCAddr: 'any address',
     lbcAddr: 'any address',
-    lpRSKAddr: 'any address',
+    lpRSKAddr: providerMock.provider,
     btcRefundAddr: 'any address',
     rskRefundAddr: 'any address',
     lpBTCAddr: 'any address',
@@ -119,6 +119,22 @@ describe('acceptAuthenticatedQuote function should', () => {
     const invalidQuote = { ...quoteMock, quote: {} as QuoteDetail }
     await expect(acceptAuthenticatedQuote(mockClient, lbcMock, providerMock, invalidQuote, signatureMock))
       .rejects.toThrow(`Validation failed for object with following missing properties: ${quoteDetailRequiredFields.join(', ')}`)
+  })
+
+  test('validate signature against quote lp address', async () => {
+    const lpAddress = '0xd6F117d8194Eba2fCA8bD63B2E259Dbea40E07d9'
+    const quote = { ...quoteMock, quote: { ...quoteMock.quote, lpRSKAddr: lpAddress } }
+    const eip712Hash = '0xeip712hash'
+    jest.spyOn(bridgesCoreSdk, 'isValidSignature').mockReturnValue(true)
+    jest.spyOn(lbcMock.pegInContract, 'hashPeginQuoteEIP712').mockResolvedValue(eip712Hash)
+
+    await acceptAuthenticatedQuote(mockClient, lbcMock, providerMock, quote, signatureMock)
+
+    expect(bridgesCoreSdk.isValidSignature).toHaveBeenCalledWith(
+      lpAddress,
+      eip712Hash,
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+    )
   })
 
   test('fail when signature is invalid', async () => {

--- a/src/sdk/acceptAuthenticatedQuote.ts
+++ b/src/sdk/acceptAuthenticatedQuote.ts
@@ -19,7 +19,7 @@ import {
       { includeCaptcha: false }
     )
     const eip712Hash = await lbc.pegInContract.hashPeginQuoteEIP712(quote)
-    if (!isValidSignature(provider.provider, eip712Hash, acceptedQuote.signature)) {
+    if (!isValidSignature(quote.quote.lpRSKAddr, eip712Hash, acceptedQuote.signature)) {
       throw FlyoverError.invalidSignatureError({
         serverUrl: provider.apiBaseUrl,
         address: quote.quote.lpRSKAddr,

--- a/src/sdk/acceptPegoutQuote.test.ts
+++ b/src/sdk/acceptPegoutQuote.test.ts
@@ -21,31 +21,6 @@ const mockClient: HttpClient = {
   getCaptchaToken: async () => Promise.resolve('')
 }
 
-const quoteMock: PegoutQuote = {
-  quote: {
-    agreementTimestamp: 1,
-    btcRefundAddress: 'any address',
-    callFee: BigInt(1),
-    depositAddr: 'any address',
-    depositConfirmations: 1,
-    depositDateLimit: 1,
-    expireBlocks: 1,
-    expireDate: 1,
-    gasFee: BigInt(1),
-    lbcAddress: 'any address',
-    liquidityProviderRskAddress: 'any address',
-    lpBtcAddr: 'any address',
-    nonce: BigInt(1),
-    penaltyFee: BigInt(1),
-    rskRefundAddress: 'any address',
-    transferConfirmations: 1,
-    transferTime: 1,
-    value: BigInt(1),
-    chainId: 31,
-  },
-  quoteHash: '8e7a1f104628f98780cb8ecf438534e9480b43525ede379995ee5838a407ef32'
-}
-
 const providerMock: LiquidityProvider = {
   id: 1,
   provider: '0x57f9F71E683E2A8ff3d2f394aE45C58b2d913A35',
@@ -71,6 +46,31 @@ const providerMock: LiquidityProvider = {
     feePercentage: 1.25,
     requiredConfirmations: 5
   }
+}
+
+const quoteMock: PegoutQuote = {
+  quote: {
+    agreementTimestamp: 1,
+    btcRefundAddress: 'any address',
+    callFee: BigInt(1),
+    depositAddr: 'any address',
+    depositConfirmations: 1,
+    depositDateLimit: 1,
+    expireBlocks: 1,
+    expireDate: 1,
+    gasFee: BigInt(1),
+    lbcAddress: 'any address',
+    liquidityProviderRskAddress: providerMock.provider,
+    lpBtcAddr: 'any address',
+    nonce: BigInt(1),
+    penaltyFee: BigInt(1),
+    rskRefundAddress: 'any address',
+    transferConfirmations: 1,
+    transferTime: 1,
+    value: BigInt(1),
+    chainId: 31,
+  },
+  quoteHash: '8e7a1f104628f98780cb8ecf438534e9480b43525ede379995ee5838a407ef32'
 }
 
 const MOCK_LIQUIDITY_BRIDGE_CONTRACT: LiquidityBridgeContract = {
@@ -117,7 +117,8 @@ describe('acceptPegoutQuote function should', () => {
   test('fail if signature is not valid', async () => {
     expect.assertions(2)
     const otherProvider: LiquidityProvider = { ...providerMock, provider: '0xd6F117d8194Eba2fCA8bD63B2E259Dbea40E07d9' }
-    await acceptPegoutQuote(mockClient,  MOCK_LIQUIDITY_BRIDGE_CONTRACT, otherProvider, quoteMock)
+    const otherQuote: PegoutQuote = { ...quoteMock, quote: { ...quoteMock.quote, liquidityProviderRskAddress: otherProvider.provider } }
+    await acceptPegoutQuote(mockClient,  MOCK_LIQUIDITY_BRIDGE_CONTRACT, otherProvider, otherQuote)
       .catch(e => {
         expect(e).toBeInstanceOf(FlyoverError)
         expect(e.message).toBe('Invalid signature')

--- a/src/sdk/acceptPegoutQuote.ts
+++ b/src/sdk/acceptPegoutQuote.ts
@@ -19,7 +19,7 @@ export async function acceptPegoutQuote (
     { includeCaptcha: true }
   )
   const eip712Hash = await lbc.pegOutContract.hashPegoutQuoteEIP712(quote)
-  if (!isValidSignature(provider.provider, eip712Hash, acceptedQuote.signature)) {
+  if (!isValidSignature(quote.quote.liquidityProviderRskAddress, eip712Hash, acceptedQuote.signature)) {
     throw FlyoverError.invalidSignatureError({
       serverUrl: provider.apiBaseUrl,
       address: quote.quote.liquidityProviderRskAddress,

--- a/src/sdk/acceptQuote.test.ts
+++ b/src/sdk/acceptQuote.test.ts
@@ -18,32 +18,6 @@ const mockClient: HttpClient = {
   getCaptchaToken: async () => Promise.resolve('')
 }
 
-const quoteMock: Quote = {
-  quote: {
-    fedBTCAddr: 'any addres',
-    lbcAddr: 'any addres',
-    lpRSKAddr: 'any addres',
-    btcRefundAddr: 'any addres',
-    rskRefundAddr: 'any addres',
-    lpBTCAddr: 'any addres',
-    callFee: BigInt(1),
-    penaltyFee: BigInt(1),
-    contractAddr: 'any addres',
-    data: 'any data',
-    gasLimit: 1,
-    nonce: BigInt(1),
-    gasFee: BigInt(1),
-    value: BigInt('9007199254750000'),
-    agreementTimestamp: 1,
-    timeForDeposit: 1,
-    lpCallTime: 1,
-    confirmations: 1,
-    callOnRegister: true,
-    chainId: 31,
-  },
-  quoteHash: 'a1a6210bc03964779067d5acf23e5076639e4621a500f8ef3f87861eaabdb6e7'
-}
-
 const providerMock: LiquidityProvider = {
   id: 1,
   provider: '0x57f9F71E683E2A8ff3d2f394aE45C58b2d913A35',
@@ -69,6 +43,32 @@ const providerMock: LiquidityProvider = {
     feePercentage: 1.25,
     requiredConfirmations: 5
   }
+}
+
+const quoteMock: Quote = {
+  quote: {
+    fedBTCAddr: 'any addres',
+    lbcAddr: 'any addres',
+    lpRSKAddr: providerMock.provider,
+    btcRefundAddr: 'any addres',
+    rskRefundAddr: 'any addres',
+    lpBTCAddr: 'any addres',
+    callFee: BigInt(1),
+    penaltyFee: BigInt(1),
+    contractAddr: 'any addres',
+    data: 'any data',
+    gasLimit: 1,
+    nonce: BigInt(1),
+    gasFee: BigInt(1),
+    value: BigInt('9007199254750000'),
+    agreementTimestamp: 1,
+    timeForDeposit: 1,
+    lpCallTime: 1,
+    confirmations: 1,
+    callOnRegister: true,
+    chainId: 31,
+  },
+  quoteHash: 'a1a6210bc03964779067d5acf23e5076639e4621a500f8ef3f87861eaabdb6e7'
 }
 
 const lbcMock = {
@@ -110,7 +110,8 @@ describe('acceptQuote function should', () => {
   test('fail if signature is not valid', async () => {
     expect.assertions(2)
     const otherProvider: LiquidityProvider = { ...providerMock, provider: '0xd6F117d8194Eba2fCA8bD63B2E259Dbea40E07d9' }
-    await acceptQuote(mockClient, lbcMock, otherProvider, quoteMock)
+    const otherQuote: Quote = { ...quoteMock, quote: { ...quoteMock.quote, lpRSKAddr: otherProvider.provider } }
+    await acceptQuote(mockClient, lbcMock, otherProvider, otherQuote)
       .catch(e => {
         expect(e).toBeInstanceOf(FlyoverError)
         expect(e.message).toBe('Invalid signature')

--- a/src/sdk/acceptQuote.ts
+++ b/src/sdk/acceptQuote.ts
@@ -18,7 +18,7 @@ export async function acceptQuote (httpClient: HttpClient, lbc: LiquidityBridgeC
     { includeCaptcha: true }
   )
   const eip712Hash = await lbc.pegInContract.hashPeginQuoteEIP712(quote)
-  if (!isValidSignature(provider.provider, eip712Hash, acceptedQuote.signature)) {
+  if (!isValidSignature(quote.quote.lpRSKAddr, eip712Hash, acceptedQuote.signature)) {
     throw FlyoverError.invalidSignatureError({
       serverUrl: provider.apiBaseUrl,
       address: quote.quote.lpRSKAddr,

--- a/src/sdk/getPegoutQuote.test.ts
+++ b/src/sdk/getPegoutQuote.test.ts
@@ -20,9 +20,11 @@ function getMockClient (): HttpClient {
   }
 }
 
+const LP_RSK_ADDRESS = '0x57f9F71E683E2A8ff3d2f394aE45C58b2d913A35'
+
 const providerMock: LiquidityProvider = {
   id: 1,
-  provider: 'any address',
+  provider: LP_RSK_ADDRESS,
   apiBaseUrl: 'http://localhost:8081',
   name: 'any name',
   status: true,
@@ -65,7 +67,7 @@ const quoteResponseMock: PegoutQuote = {
     expireDate: 1,
     gasFee: BigInt(1),
     lbcAddress: 'any address',
-    liquidityProviderRskAddress: 'any address',
+    liquidityProviderRskAddress: providerMock.provider,
     lpBtcAddr: 'any address',
     nonce: BigInt(1),
     penaltyFee: BigInt(1),
@@ -249,6 +251,28 @@ describe('getPegoutQuote function should', () => {
       expect(e.message).toBe('Quote hash mismatch')
     })
     lbcMock.pegOutContract.hashPegoutQuote = original
+  })
+
+  test('fail when liquidityProviderRskAddress does not match provider address', async () => {
+    const response = structuredClone(quoteResponseMock)
+    response.quote.liquidityProviderRskAddress = '0xd6F117d8194Eba2fCA8bD63B2E259Dbea40E07d9'
+    const mockClient = getMockClient()
+    mockClient.post = jest.fn<HttpClient['post']>().mockResolvedValue([response]) as jest.MockedFunction<HttpClient['post']>
+
+    expect.assertions(2)
+    await getPegoutQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock).catch(e => {
+      expect(e).toBeInstanceOf(FlyoverError)
+      expect(e.message).toBe('Manipulated quote response')
+    })
+  })
+
+  test('accept liquidityProviderRskAddress with different casing than provider', async () => {
+    const response = structuredClone(quoteResponseMock)
+    response.quote.liquidityProviderRskAddress = LP_RSK_ADDRESS.toLowerCase()
+    const mockClient = getMockClient()
+    mockClient.post = jest.fn<HttpClient['post']>().mockResolvedValue([response]) as jest.MockedFunction<HttpClient['post']>
+
+    await expect(getPegoutQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock)).resolves.not.toThrow()
   })
 
   test('validate response fields', async () => {

--- a/src/sdk/getPegoutQuote.test.ts
+++ b/src/sdk/getPegoutQuote.test.ts
@@ -272,7 +272,7 @@ describe('getPegoutQuote function should', () => {
     const mockClient = getMockClient()
     mockClient.post = jest.fn<HttpClient['post']>().mockResolvedValue([response]) as jest.MockedFunction<HttpClient['post']>
 
-    await expect(getPegoutQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock)).resolves.not.toThrow()
+    await expect(getPegoutQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock)).resolves.toBeDefined()
   })
 
   test('validate response fields', async () => {

--- a/src/sdk/getPegoutQuote.ts
+++ b/src/sdk/getPegoutQuote.ts
@@ -2,7 +2,7 @@ import { type FlyoverConfig, isBtcMainnetAddress, isBtcTestnetAddress, type Http
 import { type PegoutQuote, type PegoutQuoteRequest, type LiquidityProvider, providerRequiredFields, Routes, pegoutQuoteRequestRequiredFields } from '../api'
 import { type LiquidityBridgeContract } from '../blockchain/lbc'
 import { FlyoverError } from '../client/httpClient'
-import { validateRskChecksum } from '../utils/validation'
+import { compareIgnoreCase, validateRskChecksum } from '../utils/validation'
 
 export async function getPegoutQuote (
   config: FlyoverConfig,
@@ -19,7 +19,7 @@ export async function getPegoutQuote (
   const url = provider.apiBaseUrl + Routes.getPegoutQuote
   const quotes = await httpClient.post<PegoutQuote[]>(url, quoteRequest)
   for (const quote of quotes) {
-    if (!validateQuoteResponse(quoteRequest, quote)) {
+    if (!validateQuoteResponse({provider}, quoteRequest, quote)) {
       throw FlyoverError.manipulatedQuoteResonseError(provider.apiBaseUrl)
     }
     const validHash = await validateQuoteHash(lbc, quote)
@@ -35,11 +35,12 @@ async function validateQuoteHash (lbc: LiquidityBridgeContract, quote: PegoutQuo
   return hash === quote.quoteHash
 }
 
-function validateQuoteResponse (quoteRequest: PegoutQuoteRequest, quoteResponse: PegoutQuote): boolean {
+function validateQuoteResponse (context: {provider: LiquidityProvider}, quoteRequest: PegoutQuoteRequest, quoteResponse: PegoutQuote): boolean {
   const { quote } = quoteResponse
   return quoteRequest.to === quote.btcRefundAddress &&
     quoteRequest.rskRefundAddress === quote.rskRefundAddress &&
     quoteRequest.to === quote.depositAddr &&
+    compareIgnoreCase(context.provider.provider, quote.liquidityProviderRskAddress) &&
     quoteRequest.valueToTransfer === quote.value
 }
 

--- a/src/sdk/getPegoutQuote.ts
+++ b/src/sdk/getPegoutQuote.ts
@@ -2,7 +2,7 @@ import { type FlyoverConfig, isBtcMainnetAddress, isBtcTestnetAddress, type Http
 import { type PegoutQuote, type PegoutQuoteRequest, type LiquidityProvider, providerRequiredFields, Routes, pegoutQuoteRequestRequiredFields } from '../api'
 import { type LiquidityBridgeContract } from '../blockchain/lbc'
 import { FlyoverError } from '../client/httpClient'
-import { compareIgnoreCase, validateRskChecksum } from '../utils/validation'
+import { isTextEqualNoCase, validateRskChecksum } from '../utils/validation'
 
 export async function getPegoutQuote (
   config: FlyoverConfig,
@@ -40,7 +40,7 @@ function validateQuoteResponse (context: {provider: LiquidityProvider}, quoteReq
   return quoteRequest.to === quote.btcRefundAddress &&
     quoteRequest.rskRefundAddress === quote.rskRefundAddress &&
     quoteRequest.to === quote.depositAddr &&
-    compareIgnoreCase(context.provider.provider, quote.liquidityProviderRskAddress) &&
+    isTextEqualNoCase(context.provider.provider, quote.liquidityProviderRskAddress) &&
     quoteRequest.valueToTransfer === quote.value
 }
 

--- a/src/sdk/getQuote.test.ts
+++ b/src/sdk/getQuote.test.ts
@@ -229,7 +229,7 @@ describe('getQuote function should', () => {
   test('accept lpRSKAddr with different casing than provider', async () => {
     const oldQuote = quoteResponseMock.quote
     quoteResponseMock.quote = { ...oldQuote, lpRSKAddr: LP_RSK_ADDRESS.toLowerCase() }
-    await expect(getQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock)).resolves.not.toThrow()
+    await expect(getQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock)).resolves.toBeDefined()
     quoteResponseMock.quote = oldQuote
   })
 

--- a/src/sdk/getQuote.test.ts
+++ b/src/sdk/getQuote.test.ts
@@ -23,9 +23,11 @@ const mockSanitizedClient: HttpClient = {
   getCaptchaToken: async () => Promise.resolve('')
 }
 
+const LP_RSK_ADDRESS = '0x57f9F71E683E2A8ff3d2f394aE45C58b2d913A35'
+
 const providerMock: LiquidityProvider = {
   id: 1,
-  provider: 'any address',
+  provider: LP_RSK_ADDRESS,
   apiBaseUrl: 'http://localhost:8081',
   name: 'any name',
   status: true,
@@ -69,7 +71,7 @@ const quoteResponseMock: Quote =
     quote: {
       fedBTCAddr: 'any addres',
       lbcAddr: 'any addres',
-      lpRSKAddr: 'any addres',
+      lpRSKAddr: providerMock.provider,
       btcRefundAddr: BTC_ZERO_ADDRESS_MAINNET,
       rskRefundAddr: quoteRequestMock.rskRefundAddress,
       lpBTCAddr: 'any addres',
@@ -96,7 +98,7 @@ const quoteResponseSanitizedMock: Quote =
     quote: {
       fedBTCAddr: 'any addres',
       lbcAddr: 'any addres',
-      lpRSKAddr: 'any addres',
+      lpRSKAddr: providerMock.provider,
       btcRefundAddr: BTC_ZERO_ADDRESS_MAINNET,
       rskRefundAddr: quoteRequestToSanitizeMock.rskRefundAddress,
       lpBTCAddr: 'any addres',
@@ -209,6 +211,26 @@ describe('getQuote function should', () => {
       expect(e.message).toBe('Quote hash mismatch')
     })
     lbcMock.pegInContract.hashPeginQuote = original
+  })
+
+  test('fail when lpRSKAddr does not match provider address', async () => {
+    const oldQuote = quoteResponseMock.quote
+    const badQuote = structuredClone(quoteResponseMock.quote)
+    badQuote.lpRSKAddr = '0xd6F117d8194Eba2fCA8bD63B2E259Dbea40E07d9'
+    quoteResponseMock.quote = badQuote
+    expect.assertions(2)
+    await getQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock).catch(e => {
+      expect(e).toBeInstanceOf(FlyoverError)
+      expect(e.message).toBe('Manipulated quote response')
+    })
+    quoteResponseMock.quote = oldQuote
+  })
+
+  test('accept lpRSKAddr with different casing than provider', async () => {
+    const oldQuote = quoteResponseMock.quote
+    quoteResponseMock.quote = { ...oldQuote, lpRSKAddr: LP_RSK_ADDRESS.toLowerCase() }
+    await expect(getQuote(configMock, mockClient, lbcMock, providerMock, quoteRequestMock)).resolves.not.toThrow()
+    quoteResponseMock.quote = oldQuote
   })
 
   test('validate response fields', async () => {

--- a/src/sdk/getQuote.ts
+++ b/src/sdk/getQuote.ts
@@ -11,7 +11,7 @@ import {
   type PeginQuoteRequest, type Quote, type LiquidityProvider, Routes, providerRequiredFields
 } from '../api'
 import { type LiquidityBridgeContract } from '../blockchain/lbc'
-import { compareIgnoreCase, validateRskChecksum } from '../utils/validation'
+import { isTextEqualNoCase, validateRskChecksum } from '../utils/validation'
 
 export async function getQuote (
   config: FlyoverConfig,
@@ -51,7 +51,7 @@ function validateQuoteResponse (context: {config: FlyoverConfig, provider: Liqui
     quoteRequest.rskRefundAddress === quote.rskRefundAddr &&
     quoteRequest.valueToTransfer === quote.value &&
     quote.callOnRegister === false &&
-    compareIgnoreCase(context.provider.provider, quote.lpRSKAddr) &&
+    isTextEqualNoCase(context.provider.provider, quote.lpRSKAddr) &&
     isBtcZeroAddress(context.config, quote.btcRefundAddr)
 }
 

--- a/src/sdk/getQuote.ts
+++ b/src/sdk/getQuote.ts
@@ -11,7 +11,7 @@ import {
   type PeginQuoteRequest, type Quote, type LiquidityProvider, Routes, providerRequiredFields
 } from '../api'
 import { type LiquidityBridgeContract } from '../blockchain/lbc'
-import { validateRskChecksum } from '../utils/validation'
+import { compareIgnoreCase, validateRskChecksum } from '../utils/validation'
 
 export async function getQuote (
   config: FlyoverConfig,
@@ -27,7 +27,7 @@ export async function getQuote (
   const url = provider.apiBaseUrl + Routes.getQuote
   const quotes = await httpClient.post<Quote[]>(url, quoteRequest)
   for (const quote of quotes) {
-    if (!validateQuoteResponse(config, quoteRequest, quote)) {
+    if (!validateQuoteResponse({ config, provider }, quoteRequest, quote)) {
       throw FlyoverError.manipulatedQuoteResonseError(provider.apiBaseUrl)
     }
 
@@ -44,14 +44,15 @@ async function validateQuoteHash (lbc: LiquidityBridgeContract, quote: Quote): P
   return hash === quote.quoteHash
 }
 
-function validateQuoteResponse (config: FlyoverConfig, quoteRequest: PeginQuoteRequest, quoteResponse: Quote): boolean {
+function validateQuoteResponse (context: {config: FlyoverConfig, provider: LiquidityProvider}, quoteRequest: PeginQuoteRequest, quoteResponse: Quote): boolean {
   const { quote } = quoteResponse
   return quoteRequest.callContractArguments === quote.data &&
     quoteRequest.callEoaOrContractAddress === quote.contractAddr &&
     quoteRequest.rskRefundAddress === quote.rskRefundAddr &&
     quoteRequest.valueToTransfer === quote.value &&
     quote.callOnRegister === false &&
-    isBtcZeroAddress(config, quote.btcRefundAddr)
+    compareIgnoreCase(context.provider.provider, quote.lpRSKAddr) &&
+    isBtcZeroAddress(context.config, quote.btcRefundAddr)
 }
 
 function validateRskAddresses (config: FlyoverConfig, quoteRequest: PeginQuoteRequest): void {

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, jest } from '@jest/globals'
 import { type FlyoverConfig } from '@rsksmart/bridges-core-sdk'
 import * as core from '@rsksmart/bridges-core-sdk'
 import { FlyoverError } from '..'
-import { isHex, validateRskChecksum } from './validation'
+import { compareIgnoreCase, isHex, validateRskChecksum } from './validation'
 
 jest.mock('@rsksmart/bridges-core-sdk', () => {
   return {
@@ -77,6 +77,18 @@ describe('validateRskChecksum function should', () => {
       expect(e.message).toBe('Invalid RSK address checksum')
       expect(e.details).toBe(`The following addresses doesn't have a valid checksum address: ${rskMainnetAddress}, ${ethAddress}`)
     }
+  })
+})
+
+describe('compareIgnoreCase function should', () => {
+  test('return true for equal strings regardless of case', () => {
+    expect(compareIgnoreCase('0xABC', '0xabc')).toBe(true)
+    expect(compareIgnoreCase('Any Address', 'any address')).toBe(true)
+  })
+
+  test('return false for different strings', () => {
+    expect(compareIgnoreCase('0xABC', '0xABD')).toBe(false)
+    expect(compareIgnoreCase('any address', 'other address')).toBe(false)
   })
 })
 

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -90,6 +90,20 @@ describe('compareIgnoreCase function should', () => {
     expect(compareIgnoreCase('0xABC', '0xABD')).toBe(false)
     expect(compareIgnoreCase('any address', 'other address')).toBe(false)
   })
+
+  test('return true when both values are null or undefined at runtime', () => {
+    expect(compareIgnoreCase(null as unknown as string, null as unknown as string)).toBe(true)
+    expect(compareIgnoreCase(undefined as unknown as string, undefined as unknown as string)).toBe(true)
+    expect(compareIgnoreCase(null as unknown as string, undefined as unknown as string)).toBe(true)
+    expect(compareIgnoreCase(undefined as unknown as string, null as unknown as string)).toBe(true)
+  })
+
+  test('return false when only one value is null or undefined at runtime', () => {
+    expect(compareIgnoreCase(null as unknown as string, '0xabc')).toBe(false)
+    expect(compareIgnoreCase(undefined as unknown as string, '0xabc')).toBe(false)
+    expect(compareIgnoreCase('0xabc', null as unknown as string)).toBe(false)
+    expect(compareIgnoreCase('0xabc', undefined as unknown as string)).toBe(false)
+  })
 })
 
 describe('isHex function should', () => {

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, jest } from '@jest/globals'
 import { type FlyoverConfig } from '@rsksmart/bridges-core-sdk'
 import * as core from '@rsksmart/bridges-core-sdk'
 import { FlyoverError } from '..'
-import { compareIgnoreCase, isHex, validateRskChecksum } from './validation'
+import { isTextEqualNoCase, isHex, validateRskChecksum } from './validation'
 
 jest.mock('@rsksmart/bridges-core-sdk', () => {
   return {
@@ -80,30 +80,30 @@ describe('validateRskChecksum function should', () => {
   })
 })
 
-describe('compareIgnoreCase function should', () => {
+describe('isTextEqualNoCase function should', () => {
   test('return true for equal strings regardless of case', () => {
-    expect(compareIgnoreCase('0xABC', '0xabc')).toBe(true)
-    expect(compareIgnoreCase('Any Address', 'any address')).toBe(true)
-    expect(compareIgnoreCase('', '')).toBe(true)
+    expect(isTextEqualNoCase('0xABC', '0xabc')).toBe(true)
+    expect(isTextEqualNoCase('Any Address', 'any address')).toBe(true)
+    expect(isTextEqualNoCase('', '')).toBe(true)
   })
 
   test('return false for different strings', () => {
-    expect(compareIgnoreCase('0xABC', '0xABD')).toBe(false)
-    expect(compareIgnoreCase('any address', 'other address')).toBe(false)
+    expect(isTextEqualNoCase('0xABC', '0xABD')).toBe(false)
+    expect(isTextEqualNoCase('any address', 'other address')).toBe(false)
   })
 
   test('return true when both values are null or undefined at runtime', () => {
-    expect(compareIgnoreCase(null as unknown as string, null as unknown as string)).toBe(true)
-    expect(compareIgnoreCase(undefined as unknown as string, undefined as unknown as string)).toBe(true)
+    expect(isTextEqualNoCase(null as unknown as string, null as unknown as string)).toBe(true)
+    expect(isTextEqualNoCase(undefined as unknown as string, undefined as unknown as string)).toBe(true)
   })
 
   test('return false when only one value is null or undefined at runtime', () => {
-    expect(compareIgnoreCase(null as unknown as string, '0xabc')).toBe(false)
-    expect(compareIgnoreCase(undefined as unknown as string, '0xabc')).toBe(false)
-    expect(compareIgnoreCase('0xabc', null as unknown as string)).toBe(false)
-    expect(compareIgnoreCase('0xabc', undefined as unknown as string)).toBe(false)
-    expect(compareIgnoreCase(null as unknown as string, undefined as unknown as string)).toBe(false)
-    expect(compareIgnoreCase(undefined as unknown as string, null as unknown as string)).toBe(false)
+    expect(isTextEqualNoCase(null as unknown as string, '0xabc')).toBe(false)
+    expect(isTextEqualNoCase(undefined as unknown as string, '0xabc')).toBe(false)
+    expect(isTextEqualNoCase('0xabc', null as unknown as string)).toBe(false)
+    expect(isTextEqualNoCase('0xabc', undefined as unknown as string)).toBe(false)
+    expect(isTextEqualNoCase(null as unknown as string, undefined as unknown as string)).toBe(false)
+    expect(isTextEqualNoCase(undefined as unknown as string, null as unknown as string)).toBe(false)
   })
 })
 

--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -84,6 +84,7 @@ describe('compareIgnoreCase function should', () => {
   test('return true for equal strings regardless of case', () => {
     expect(compareIgnoreCase('0xABC', '0xabc')).toBe(true)
     expect(compareIgnoreCase('Any Address', 'any address')).toBe(true)
+    expect(compareIgnoreCase('', '')).toBe(true)
   })
 
   test('return false for different strings', () => {
@@ -94,8 +95,6 @@ describe('compareIgnoreCase function should', () => {
   test('return true when both values are null or undefined at runtime', () => {
     expect(compareIgnoreCase(null as unknown as string, null as unknown as string)).toBe(true)
     expect(compareIgnoreCase(undefined as unknown as string, undefined as unknown as string)).toBe(true)
-    expect(compareIgnoreCase(null as unknown as string, undefined as unknown as string)).toBe(true)
-    expect(compareIgnoreCase(undefined as unknown as string, null as unknown as string)).toBe(true)
   })
 
   test('return false when only one value is null or undefined at runtime', () => {
@@ -103,6 +102,8 @@ describe('compareIgnoreCase function should', () => {
     expect(compareIgnoreCase(undefined as unknown as string, '0xabc')).toBe(false)
     expect(compareIgnoreCase('0xabc', null as unknown as string)).toBe(false)
     expect(compareIgnoreCase('0xabc', undefined as unknown as string)).toBe(false)
+    expect(compareIgnoreCase(null as unknown as string, undefined as unknown as string)).toBe(false)
+    expect(compareIgnoreCase(undefined as unknown as string, null as unknown as string)).toBe(false)
   })
 })
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -15,7 +15,14 @@ export function validateRskChecksum (config: FlyoverConfig, ...addresses: string
 
 export const isHex = (value: string) => /^(0x)?([0-9A-Fa-f]{2})*$/.test(value)
 
-export const compareIgnoreCase = (str1: string, str2: string): boolean => {
+/**
+ * Compares two strings for equality, ignoring case. If any of the values is falsy,
+ * it returns true only if they are the exact same falsy value
+ * @param str1 a string to compare
+ * @param str2 another string to compare
+ * @returns whether they are the same or not, ignoring case
+ */
+export const isTextEqualNoCase = (str1: string, str2: string): boolean => {
   if (!str1 || !str2) {
     return str1 === str2
   }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -16,5 +16,8 @@ export function validateRskChecksum (config: FlyoverConfig, ...addresses: string
 export const isHex = (value: string) => /^(0x)?([0-9A-Fa-f]{2})*$/.test(value)
 
 export const compareIgnoreCase = (str1: string, str2: string): boolean => {
-  return str1?.toLowerCase() === str2?.toLowerCase()
+  if (!str1 || !str2) {
+    return str1 === str2
+  }
+  return str1.toLowerCase() === str2.toLowerCase()
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -16,5 +16,5 @@ export function validateRskChecksum (config: FlyoverConfig, ...addresses: string
 export const isHex = (value: string) => /^(0x)?([0-9A-Fa-f]{2})*$/.test(value)
 
 export const compareIgnoreCase = (str1: string, str2: string): boolean => {
-  return str1.toLowerCase() === str2.toLowerCase()
+  return str1?.toLowerCase() === str2?.toLowerCase()
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -14,3 +14,7 @@ export function validateRskChecksum (config: FlyoverConfig, ...addresses: string
 }
 
 export const isHex = (value: string) => /^(0x)?([0-9A-Fa-f]{2})*$/.test(value)
+
+export const compareIgnoreCase = (str1: string, str2: string): boolean => {
+  return str1.toLowerCase() === str2.toLowerCase()
+}


### PR DESCRIPTION
## What
Add validations about the LP address in get quote, also validate the signature using the address present in the quote

## Why
To avoid working with quotes whose LP address is different from the one announced in discovery

## Task
https://rsklabs.atlassian.net/browse/FLY-2326