### PR TITLE
Feat/Fly2278 execute integration tests in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,114 @@
+name: Flyover SDK Integration Tests
+
+on:
+  pull_request:
+
+permissions: read-all
+
+env:
+  LPS_REF: v2.6.0
+
+jobs:
+  integration:
+    name: Integration tests (regtest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: '22.12.0'
+
+      - name: NPM Login
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm config set //npm.pkg.github.com/:_authToken $GITHUB_TOKEN
+
+      - name: Clone LPS at pinned ref
+        run: |
+          git clone --depth 1 --branch "$LPS_REF" \
+            https://github.com/rsksmart/liquidity-provider-server.git lps
+
+      - name: Prepare .env.regtest file
+        working-directory: lps/docker-compose/local
+        run: |
+          cp ../../sample-config.env .env.regtest
+          # Powpeg + segwit federation migration are mandatory for the SDK tests
+          sed -i 's/^CREATE_POWPEG=.*/CREATE_POWPEG=true/' .env.regtest
+          sed -i 's/^MIGRATE_FEDERATION=.*/MIGRATE_FEDERATION=true/' .env.regtest
+          # Route LPS logs to stdout so `docker compose logs` captures them
+          sed -i 's|^LOG_FILE=.*|LOG_FILE=|' .env.regtest
+          # Pre-create all volume directories with open permissions so Docker doesn't
+          # create them as root, which causes "permission denied" for container users
+          mkdir -p volumes/lps/logs volumes/lps/db volumes/localstack volumes/bitcoind \
+            volumes/rskj/db volumes/rskj/logs volumes/mongo
+          chmod -R 777 volumes/
+          # lps_configuration_data is mounted as /tmp inside the LPS container;
+          # must be writable by the lps user (uid 1000) for management_password.txt
+          mkdir -p lps/lps_configuration_data
+          chmod 777 lps/lps_configuration_data
+
+      - name: Run lps-local.sh script
+        working-directory: lps/docker-compose/local
+        run: bash lps-local.sh
+
+      - name: Mine BTC blocks for fee estimation
+        working-directory: lps/docker-compose/local
+        run: |
+          BTC_CLI="docker exec bitcoind01 bitcoin-cli -rpcuser=test -rpcpassword=test -rpcport=5555"
+          ADDR="mni1YpzHTXrrTtP2AVzwzdkTY6ni5uhJ3U"
+          # Unlock the wallet encrypted by wallet-funder with this passphrase.
+          $BTC_CLI -rpcwallet=main walletpassphrase "test-password" 300000
+          # Mine 100 blocks with fee-paying transactions so Bitcoin's estimatesmartfee
+          # has sufficient data
+          for i in $(seq 1 100); do
+            $BTC_CLI -rpcwallet=main generatetoaddress 1 "$ADDR" > /dev/null
+            $BTC_CLI -rpcwallet=main -named sendtoaddress \
+              address="$ADDR" amount=0.00001 fee_rate=25 > /dev/null
+          done
+          echo "Mined 100 BTC blocks with fee-paying transactions for estimatesmartfee"
+
+      - name: Generate integration-test/.env
+        run: |
+          PEGIN_CONTRACT_ADDRESS=$(grep '^PEGIN_CONTRACT_ADDRESS=' lps/docker-compose/local/.env.regtest | cut -d= -f2)
+          cat > integration-test/.env << EOF
+          TEST_NETWORK=Regtest
+          TEST_MNEMONIC="test test test test test test test test test test test junk"
+          TEST_PROVIDER_ID=1
+          TEST_NODE_URL=http://localhost:4444
+          TEST_RSK_ADDRESS=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
+          TEST_BTC_ADDRESS=n1jGDaxCW6jemLZyd9wmDHddseZwEMV9C6
+          TEST_PEGIN_AMOUNT=600000000000000000
+          TEST_PEGOUT_AMOUNT=600000000000000000
+          TEST_MEMPOOL_SPACE_URL=http://localhost:1
+          TEST_CONTRACT_ADDRESS=$PEGIN_CONTRACT_ADDRESS
+          TEST_BTC_RPC_PORT=5555
+          TEST_BTC_RPC_USER=test
+          TEST_BTC_RPC_PASSWORD=test
+          TEST_BTC_RPC_CONNECT=127.0.0.1
+          EOF
+
+      - name: Build SDK and run integration tests
+        run: |
+          npm ci && npm run build
+          cd integration-test && npm ci
+          set -a; source .env; set +a
+          npx jest --verbose --testPathPattern="/pegin\.test|/pegout\.test|/rsk\.test|/providers\.test|/user\.test|/client\.test" 2>&1 | tee ../jest-output.txt
+          exit ${PIPESTATUS[0]}
+
+      - name: Collect failure logs
+        if: failure()
+        run: docker compose -p local logs > lps/docker-compose/local/container-logs.txt 2>&1 || true
+
+      - name: Upload artifacts
+        if: failure()
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: integration-test-failure
+          path: |
+            jest-output.txt
+            lps/docker-compose/local/container-logs.txt
+          retention-days: 7

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,9 @@ jobs:
           # Pre-create all volume directories with open permissions so Docker doesn't
           # create them as root, which causes "permission denied" for container users
           mkdir -p volumes/lps/logs volumes/lps/db volumes/localstack volumes/bitcoind \
-            volumes/rskj/db volumes/rskj/logs volumes/mongo
+            volumes/rskj/db volumes/rskj/logs volumes/mongo \
+            volumes/powpeg/pegin/db volumes/powpeg/pegin/logs \
+            volumes/powpeg/pegout/db volumes/powpeg/pegout/logs
           chmod -R 777 volumes/
           # lps_configuration_data is mounted as /tmp inside the LPS container;
           # must be writable by the lps user (uid 1000) for management_password.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,6 +41,10 @@ jobs:
           sed -i 's/^MIGRATE_FEDERATION=.*/MIGRATE_FEDERATION=true/' .env.regtest
           # Route LPS logs to stdout so `docker compose logs` captures them
           sed -i 's|^LOG_FILE=.*|LOG_FILE=|' .env.regtest
+          # The lbc-deployer bind-mounts this file and writes the deployed contract
+          # addresses back to it; make it writable by the container user. Must run
+          # after the sed -i edits above, which rewrite the file and reset its mode.
+          chmod 666 .env.regtest
           # Pre-create all volume directories with open permissions so Docker doesn't
           # create them as root, which causes "permission denied" for container users
           mkdir -p volumes/lps/logs volumes/lps/db volumes/localstack volumes/bitcoind \

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -4,7 +4,7 @@ The Flyover integration test suite can be run by executing `npm run test:integra
 ## Environment variables
 To run the integration test suite, the following environment variables are required:
 - **TEST_NETWORK**: network to use when creating FlyoverSDK instance.
-- **TEST_MNEMONIC**: seed prhase for the test wallet that will be used to sign the pegout transaction
+- **TEST_MNEMONIC**: seed phrase for the test wallet that will be used to sign the pegout transaction
 - **TEST_PROVIDER_ID**: id of the liquidity provider that will be used to run the integration test suite.
 - **TEST_NODE_URL**: url of the RSK node that will be used.
 - **TEST_RSK_ADDRESS**: RSK address to use as pegin destination address.
@@ -12,3 +12,25 @@ To run the integration test suite, the following environment variables are requi
 - **TEST_PEGIN_AMOUNT**: amount of the test pegins.
 - **TEST_PEGOUT_AMOUNT**: amount of the test pegouts.
 - **TEST_MEMPOOL_SPACE_URL**: MempoolSpace API url. This is used to fetch some UTXO information during the tests.
+
+## Running in CI
+
+The workflow `.github/workflows/integration.yml` runs automatically on every pull request.
+
+### What it does
+
+1. Clones the LPS repo at the pinned ref (`LPS_REF:` at the top of the workflow file — update this to change the stack version).
+2. Prepares `.env.regtest` from `sample-config.env` with three CI-specific overrides:
+   - `CREATE_POWPEG=true` and `MIGRATE_FEDERATION=true` are forced explicitly (both are mandatory for the SDK tests).
+   - `LOG_FILE=` (empty) redirects LPS output to stdout so `docker compose logs` captures it.
+   - All Docker volume directories are pre-created with open permissions (`chmod 777`) so containers don't hit "permission denied" when writing to host-mounted paths. This includes `lps_configuration_data`, which is mounted as `/tmp` inside the LPS container and must be writable for `management_password.txt`.
+3. Brings up the full regtest stack via `lps-local.sh`: bitcoind, RSKj, MongoDB, LocalStack, wallet-funder, lbc-deployer, powpeg nodes, segwit federation migration, and the LPS itself with its configurer.
+4. Mines 100 Bitcoin blocks with fee-paying transactions so that `estimatesmartfee` has sufficient history for pegout quote requests to succeed.
+5. Extracts the deployed `PEGIN_CONTRACT_ADDRESS` from `.env.regtest` and generates `integration-test/.env` with all required `TEST_*` variables.
+6. Builds the SDK (`npm ci && npm run build`) and runs the following suites via `--testPathPattern`:
+   - `pegin.test.ts`, `pegout.test.ts` — core bridge flows
+   - `rsk.test.ts` — RSK connection variants
+   - `providers.test.ts` — available liquidity reads
+   - `user.test.ts` — user quote history
+   - `client.test.ts` — BigInt serialization / deserialization
+7. On failure, uploads jest output and Docker container logs as a downloadable artifact (`integration-test-failure`).

--- a/integration-test/test/pegin.test.ts
+++ b/integration-test/test/pegin.test.ts
@@ -6,6 +6,8 @@ import { fakeTokenResolver, getUtxosFromMempoolSpace } from './common/utils'
 import { Transaction, payments, networks } from 'bitcoinjs-lib'
 import { EXTENDED_TIMEOUT, TEST_CONTRACT_ABI } from './common/constants'
 
+const skipInCI = process.env.CI != null ? test.skip : test
+
 describe('Flyover pegin process should', () => {
   let flyover: Flyover
   let provider: LiquidityProvider
@@ -166,7 +168,8 @@ describe('Flyover pegin process should', () => {
   })
 
   // Skipped in CI: requires fetching UTXOs from mempool.space which has no regtest equivalent.
-  test.skip('validate the PegIn deposit transaction', async () => {
+  // Runs locally when TEST_MEMPOOL_SPACE_URL points to a real mempool.space instance.
+  skipInCI('validate the PegIn deposit transaction', async () => {
     const tx = new Transaction()
     const options: ValidatePeginTransactionOptions = {
       throwError: true
@@ -222,8 +225,9 @@ describe('Flyover pegin process should', () => {
     expect(result.recommendedQuoteValue.toString()).toEqual(quote.quote.value.toString());
   }, EXTENDED_TIMEOUT)
 
-  // Skipped in CI: requires a TestContract deployed to regtest (TEST_CONTRACT_ADDRESS).
-  test.skip('get a smart contract interaction quote', async () => {
+  // Skipped in CI: requires a TestContract deployed and TEST_CONTRACT_ADDRESS set to its address.
+  // Runs locally when the contract is available.
+  skipInCI('get a smart contract interaction quote', async () => {
     const smartContractData = new ethers.utils.Interface(TEST_CONTRACT_ABI)
       .encodeFunctionData('save', [integrationTestConfig.rskAddress])
     flyover.useLiquidityProvider(provider)

--- a/integration-test/test/pegin.test.ts
+++ b/integration-test/test/pegin.test.ts
@@ -165,7 +165,8 @@ describe('Flyover pegin process should', () => {
     expect(creationData.feePercentage).not.toBeUndefined()
   })
 
-  test('validate the PegIn deposit transaction', async () => {
+  // Skipped in CI: requires fetching UTXOs from mempool.space which has no regtest equivalent.
+  test.skip('validate the PegIn deposit transaction', async () => {
     const tx = new Transaction()
     const options: ValidatePeginTransactionOptions = {
       throwError: true
@@ -221,7 +222,8 @@ describe('Flyover pegin process should', () => {
     expect(result.recommendedQuoteValue.toString()).toEqual(quote.quote.value.toString());
   }, EXTENDED_TIMEOUT)
 
-  test('get a smart contract interaction quote', async () => {
+  // Skipped in CI: requires a TestContract deployed to regtest (TEST_CONTRACT_ADDRESS).
+  test.skip('get a smart contract interaction quote', async () => {
     const smartContractData = new ethers.utils.Interface(TEST_CONTRACT_ABI)
       .encodeFunctionData('save', [integrationTestConfig.rskAddress])
     flyover.useLiquidityProvider(provider)


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that runs the SDK integration tests against an ephemeral regtest stack on every pull request:
- Adds `.github/workflows/integration.yml`: clones LPS at a pinned ref, brings up the full regtest stack (bitcoind, RSKj, MongoDB, LocalStack, powpeg nodes, segwit federation migration, and LPS), mines 100 BTC blocks for fee estimation data, generates `integration-test/.env`, builds the SDK, and runs 6 integration test suites
- Updates `integration-test/README.md` to document the CI path

## Why
Integration tests were only run when a developer remembered to do so locally with a fully wired `.env`. Nothing gated merges on them, meaning regressions in real pegin/pegout flows were only caught at release time or by QA. This workflow makes the integration suite a required PR check.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Performance improvement
- [x] Test updates
- [ ] Security fix
- [x] Deployment/Infrastructure changes

## Affected part of the project
- [ ] Management UI / API
- [ ] PegIn flow
- [ ] PegOut flow
- [ ] Utility scripts
- [x] Configuration files
- [ ] Metrics and alerting

## Related Issues
[Jira ticket](https://rsklabs.atlassian.net/browse/FLY-2278)

## How to test
1. Open a PR touching any file — the `Integration tests (regtest)` check should appear alongside the existing `Code integrity validation` check
2. Introduce a deliberate break in `src/` (e.g. return wrong data from a quote function) and confirm the PR check turns red
3. Check the `integration-test-failure` artifact on a failed run — it should contain `jest-output.txt` and `container-logs.txt`

Check the current PR CI to validate that it ran.
