### PR TITLE
FLY-2591: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,11 @@ jobs:
         run: npm ci && npm run build
       - name: Validate code format
         run: npm run lint:validation
-      - name: Run unit tests
-        run: npm run test
+      - name: Run unit tests with coverage
+        run: npm run test:coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,20 @@ jobs:
         run: npm run lint:validation
       - name: Run unit tests with coverage
         run: npm run test:coverage
+      - name: Check for Codecov token
+        id: codecov_token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "$CODECOV_TOKEN" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning title=Coverage not uploaded::CODECOV_TOKEN is not available, so the Codecov upload was skipped. Expected on pull requests from forks, where Actions secrets are not exposed; otherwise the repository still needs to be onboarded to Codecov and the secret added."
+            echo ":warning: **Coverage not uploaded** — \`CODECOV_TOKEN\` is not available, so the Codecov upload was skipped." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Upload coverage to Codecov
+        if: steps.codecov_token.outputs.configured == 'true'
         uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rsksmart/flyover-sdk/badge)](https://scorecard.dev/viewer/?uri=github.com/rsksmart/flyover-sdk)
 [![CodeQL](https://github.com/rsksmart/flyover-sdk/workflows/CodeQL/badge.svg)](https://github.com/rsksmart/flyover-sdk/actions?query=workflow%3ACodeQL)
 [![CI](https://github.com/rsksmart/flyover-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/rsksmart/flyover-sdk/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/rsksmart/flyover-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/rsksmart/flyover-sdk)
 
 Flyover SDK simplifies the integration between client applications and the components of the Flyover Protocol by providing an easy to use interface.
 ## Installation

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto    # baseline is always the current main value
+        threshold: 1%   # allow up to 1% drop before failing the check
+    patch:
+      default:
+        target: 80%     # new/changed lines in a PR must be at least 80% covered
+        threshold: 5%   # allow up to 5% below target before failing
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true  # only post a comment when coverage actually changes
+
+ignore:
+  - "src/api/bindings/**"        # generated from the LPS OpenAPI spec
+  - "src/blockchain/bindings/**" # typechain-generated contract bindings
+  - "src/index.ts"               # re-export barrel only
+  - "**/*.test.ts"
+  - "integration-test/**"
+  - "lib/**"                     # build output
+  - "scripts/**"


### PR DESCRIPTION
## What

- Add `codecov.yml` at the repo root with the same thresholds `liquidity-provider-server` uses: project target `auto` with a 1% allowed drop, patch target 80% with a 5% allowed shortfall.
- CI now runs `npm run test:coverage` instead of `npm run test`, then uploads `coverage/lcov.info` with `codecov/codecov-action` (SHA-pinned to v5.5.5, matching how this repo pins every action).
- The upload is gated on a preceding step that checks whether `CODECOV_TOKEN` is set. Without a token the upload is skipped and the run emits a warning annotation plus a job-summary line, instead of failing the whole job.
- Add a Codecov badge to the README next to the CI and CodeQL badges.

No change to jest config was needed. `jest.config.js` already lists `lcov` in `coverageReporters` and writes to `coverage/`, and `coverage/` is already in `.gitignore`.

## Why

Integrators consume this SDK directly, so an untested regression reaches third parties instead of stopping inside the squad. `npm run test:coverage` already existed but nothing read its output. With this change each PR gets a coverage delta comment and the README shows the current number, the same setup LPS has today.

## Why the upload is gated

A step-level `if:` cannot read the `secrets` context, so the token is surfaced through `env` on a `Check for Codecov token` step that writes `configured=true|false` to `$GITHUB_OUTPUT`; the upload reads that output.

Two cases need it. The repository is not yet onboarded to Codecov and has no `CODECOV_TOKEN` secret, so without the gate `fail_ci_if_error: true` fails every CI run. And pull requests from forks never receive Actions secrets, so that case does not go away once onboarding lands.

`fail_ci_if_error: true` is kept deliberately. The gate only skips the step when there is no token at all. Once the secret exists, a genuine upload failure still fails the job.

A skipped upload is not silent: it shows as a `Coverage not uploaded` warning on the checks tab and in the run summary.

## How to verify

- `npm ci && npm run test:coverage` writes `coverage/lcov.info`. Verified locally: 39 suites, 357 tests pass, and the file lands at that path.
- Both YAML files parse (checked with `js-yaml`).
- The `ignore:` list in `codecov.yml` covers the generated and non-source paths of this repo: `src/api/bindings/**`, `src/blockchain/bindings/**`, `src/index.ts`, `**/*.test.ts`, `integration-test/**`, `lib/**`, `scripts/**`. It mirrors the existing `coveragePathIgnorePatterns` in `jest.config.js`.

## QA

Four checks. The first two are the regression this PR fixes; the last two prove the gate did not simply make CI unconditionally green.

### 1. Confirm the old behaviour failed

Open the CI run for commit `290cdec` (the previous head of this branch). `Code integrity validation` fails, and the failing step is `Upload coverage to Codecov`, not a test or lint step.

### 2. Confirm the new behaviour passes, with the skip visible

Open the CI run for the current head. Expect all of:

- `Code integrity validation` passes.
- The step `Upload coverage to Codecov` is marked skipped, not green. A green upload would mean a token appeared and the gate was never exercised.
- The run page shows a warning annotation titled `Coverage not uploaded`.
- The job summary shows the same message.

### 3. Exercise the gate logic locally, both branches

```bash
git clone git@github.com:rsksmart/flyover-sdk.git
cd flyover-sdk
git checkout feature/FLY-2591
npm ci && npm run build
npm run test:coverage
ls -l coverage/lcov.info    # the file the upload step would send
```

Save the gate script exactly as CI runs it:

```bash
cat > /tmp/gate.sh <<'SCRIPT'
if [ -n "$CODECOV_TOKEN" ]; then
  echo "configured=true" >> "$GITHUB_OUTPUT"
else
  echo "configured=false" >> "$GITHUB_OUTPUT"
  echo "::warning title=Coverage not uploaded::CODECOV_TOKEN is not available, so the Codecov upload was skipped."
  echo ":warning: **Coverage not uploaded**" >> "$GITHUB_STEP_SUMMARY"
fi
SCRIPT
```

Run it with no token:

```bash
export GITHUB_OUTPUT=$(mktemp) GITHUB_STEP_SUMMARY=$(mktemp)
unset CODECOV_TOKEN
bash /tmp/gate.sh
cat "$GITHUB_OUTPUT"          # expect: configured=false
cat "$GITHUB_STEP_SUMMARY"    # expect: the warning line
```

Run it with a token:

```bash
export GITHUB_OUTPUT=$(mktemp) GITHUB_STEP_SUMMARY=$(mktemp)
export CODECOV_TOKEN=dummy-value
bash /tmp/gate.sh
cat "$GITHUB_OUTPUT"          # expect: configured=true
cat "$GITHUB_STEP_SUMMARY"    # expect: empty
```

`configured=true` is what makes the upload step run, so this is the path that will be taken once the real secret is added.

### 4. Confirm CI still fails when it should

The gate must not mask real failures. On a scratch branch, break something and push:

```bash
git checkout -b qa/FLY-2591-still-fails
# in any src/**/*.test.ts, change one expected value so the assertion fails
npm run test:coverage         # expect a non-zero exit locally
git commit -am "QA: deliberately failing test, do not merge"
git push origin qa/FLY-2591-still-fails
```

Open a draft PR from that branch. `Code integrity validation` must fail at `Run unit tests with coverage`, before the gate is ever reached. Delete the branch afterwards.

## Follow-up, not a blocker

Codecov onboarding for this repository and the `CODECOV_TOKEN` secret are tracked separately. Until that lands, coverage is computed on every run but not published, and the README badge will read `unknown`. Adding the secret is the only step needed to turn uploads on; no further change to this workflow is required.

Out of scope, per the ticket: raising the coverage number, and making the Codecov check required for merge.

## Related issues

- Jira: [FLY-2591](https://rsklabs.atlassian.net/browse/FLY-2591)
- Follow-up: [FLY-2600](https://rsklabs.atlassian.net/browse/FLY-2600) (Codecov onboarding + `CODECOV_TOKEN` secret)
